### PR TITLE
Keep rendering metadata before start position.

### DIFF
--- a/.run/androidx-media publishToMavenLocal.run.xml
+++ b/.run/androidx-media publishToMavenLocal.run.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="androidx-media publishToMavenLocal" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="publishToMavenLocal" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2" />
+  </configuration>
+</component>

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/metadata/MetadataRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/metadata/MetadataRenderer.java
@@ -250,8 +250,12 @@ public final class MetadataRenderer extends BaseRenderer implements Callback {
         if (buffer.isEndOfStream()) {
           inputStreamEnded = true;
           Log.v(Log.LOG_LEVEL_VERBOSE2, TAG, "readMetadata buffer.isEndOfStream()");
-        } else if (buffer.timeUs >= getLastResetPositionUs()) {
+
+          // MIREGO START: One ads metadata happens before start position, we want to process it.
+        } else /* if (buffer.timeUs >= getLastResetPositionUs()) } */ {
           // Ignore metadata before start position.
+          // MIREGO END
+
           buffer.subsampleOffsetUs = subsampleOffsetUs;
           buffer.flip();
           @Nullable Metadata metadata = castNonNull(decoder).decode(buffer);

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -1508,7 +1508,8 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer implements Video
             (systemTimeUs - lastRender) / 1000, skipCount, earlyUs);
         if ( (timeSinceLastRender > Util.timeSinceLastVideoRenderToLogErrorMs * 1000) && !hasNotifiedAvDesyncSkippedFramesError) {
           hasNotifiedAvDesyncSkippedFramesError = true;
-          Log.e(TAG, new PlaybackException("AV desync: skipped video frames for more than 500 ms", new RuntimeException(), PlaybackException.ERROR_CODE_AUDIO_VIDEO_DESYNC));
+          // MIREGO: Deactivate the error for now, too many false positives
+          // Log.e(TAG, new PlaybackException("AV desync: skipped video frames for more than 500 ms", new RuntimeException(), PlaybackException.ERROR_CODE_AUDIO_VIDEO_DESYNC));
         }
       }
     }


### PR DESCRIPTION
Our first ads event was discarded since its buffer.timeUs was before the current keyframe. We want to process it anyway.

I also added a run configuration of the publishToMavenLocal, it is useful when testing locally.