### PR TITLE
FTVPI-1553: Dolby passthrough on Gen 1 FireTV

### DIFF
--- a/libraries/common/src/main/java/androidx/media3/common/MimeTypes.java
+++ b/libraries/common/src/main/java/androidx/media3/common/MimeTypes.java
@@ -81,6 +81,7 @@ public final class MimeTypes {
   public static final String AUDIO_E_AC3 = BASE_TYPE_AUDIO + "/eac3";
   public static final String AUDIO_E_AC3_JOC = BASE_TYPE_AUDIO + "/eac3-joc";
   public static final String AUDIO_AC4 = BASE_TYPE_AUDIO + "/ac4";
+  public static final String AUDIO_CUSTOM_EC3 = BASE_TYPE_AUDIO + "/ec3"; // MIREGO - AMZN_CHANGE_ONELINE
   public static final String AUDIO_TRUEHD = BASE_TYPE_AUDIO + "/true-hd";
   public static final String AUDIO_DTS = BASE_TYPE_AUDIO + "/vnd.dts";
   public static final String AUDIO_DTS_HD = BASE_TYPE_AUDIO + "/vnd.dts.hd";
@@ -595,6 +596,7 @@ public final class MimeTypes {
         return objectType.getEncoding();
       case MimeTypes.AUDIO_AC3:
         return C.ENCODING_AC3;
+      case MimeTypes.AUDIO_CUSTOM_EC3: // MIREGO - AMZN_CHANGE_ONELINE
       case MimeTypes.AUDIO_E_AC3:
         return C.ENCODING_E_AC3;
       case MimeTypes.AUDIO_E_AC3_JOC:
@@ -603,6 +605,10 @@ public final class MimeTypes {
         return C.ENCODING_AC4;
       case MimeTypes.AUDIO_DTS:
         return C.ENCODING_DTS;
+      // MIREGO - AMZN_CHANGE_BEGIN
+      case MimeTypes.AUDIO_RAW:
+        return C.ENCODING_PCM_16BIT;
+      // MIREGO - AMZN_CHANGE_END
       case MimeTypes.AUDIO_DTS_HD:
         return C.ENCODING_DTS_HD;
       case MimeTypes.AUDIO_DTS_EXPRESS:

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioTimestampPoller.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioTimestampPoller.java
@@ -119,7 +119,10 @@ import java.lang.annotation.Target;
       updateState(STATE_NO_TIMESTAMP);
     }
   }
-
+  // MIREGO - AMZN_CHANGE_BEGIN
+  public boolean maybePollTimestamp(long systemTimeUs) {
+    return maybePollTimestamp(systemTimeUs, false);
+  }
   /**
    * Polls the timestamp if required and returns whether it was updated. If {@code true}, the latest
    * timestamp is available via {@link #getTimestampSystemTimeUs()} and {@link
@@ -130,17 +133,19 @@ import java.lang.annotation.Target;
    * @param systemTimeUs The current system time, in microseconds.
    * @return Whether the timestamp was updated.
    */
-  @TargetApi(19) // audioTimestamp will be null if Util.SDK_INT < 19.
-  public boolean maybePollTimestamp(long systemTimeUs) {
-    if (audioTimestamp == null || (systemTimeUs - lastTimestampSampleTimeUs) < sampleIntervalUs) {
+  @TargetApi(19)
+  public boolean maybePollTimestamp(long systemTimeUs, boolean applyDolbyPassthroughQuirk) {
+    if (!applyDolbyPassthroughQuirk
+        && (audioTimestamp == null || (systemTimeUs - lastTimestampSampleTimeUs) < sampleIntervalUs)) {
       return false;
     }
+    // MIREGO - AMZN_CHANGE_END
     lastTimestampSampleTimeUs = systemTimeUs;
     boolean updatedTimestamp = audioTimestamp.maybeUpdateTimestamp();
     switch (state) {
       case STATE_INITIALIZING:
         if (updatedTimestamp) {
-          if (audioTimestamp.getTimestampSystemTimeUs() >= initializeSystemTimeUs) {
+          if (audioTimestamp.getTimestampSystemTimeUs() >= initializeSystemTimeUs || applyDolbyPassthroughQuirk) { // MIREGO - AMZN_CHANGE_ONELINE
             // We have an initial timestamp, but don't know if it's advancing yet.
             initialTimestampPositionFrames = audioTimestamp.getTimestampPositionFrames();
             updateState(STATE_TIMESTAMP);

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioTimestampPoller.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioTimestampPoller.java
@@ -133,7 +133,7 @@ import java.lang.annotation.Target;
    * @param systemTimeUs The current system time, in microseconds.
    * @return Whether the timestamp was updated.
    */
-  @TargetApi(19)
+  @TargetApi(19) // audioTimestamp will be null if Util.SDK_INT < 19.
   public boolean maybePollTimestamp(long systemTimeUs, boolean applyDolbyPassthroughQuirk) {
     if (!applyDolbyPassthroughQuirk
         && (audioTimestamp == null || (systemTimeUs - lastTimestampSampleTimeUs) < sampleIntervalUs)) {

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioTrackPositionTracker.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioTrackPositionTracker.java
@@ -306,7 +306,7 @@ import java.lang.reflect.Method;
     long positionUs;
     AudioTimestampPoller audioTimestampPoller = checkNotNull(this.audioTimestampPoller);
     boolean useGetTimestampMode = audioTimestampPoller.hasAdvancingTimestamp();
-    // MIREGO - AMZN_CHANGE_START
+    // MIREGO - AMZN_CHANGE_BEGIN
     // for dolby passthrough case, we just depend on getTimeStamp API
     // for audio video synchronization.
     if (applyDolbyPassThroughQuirk) {

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioTrackPositionTracker.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioTrackPositionTracker.java
@@ -42,7 +42,7 @@ import java.lang.reflect.Method;
  * Wraps an {@link AudioTrack}, exposing a position based on {@link
  * AudioTrack#getPlaybackHeadPosition()} and {@link AudioTrack#getTimestamp(AudioTimestamp)}.
  *
- * <p>Call {@link #setAudioTrack(AudioTrack, boolean, int, int, int)} to set the audio track to
+ * <p>Call {@link #setAudioTrack(AudioTrack, boolean, int, int, int, boolean)} to set the audio track to
  * wrap. Call {@link #mayHandleBuffer(long)} if there is input data to write to the track. If it
  * returns false, the audio track position is stabilizing and no data may be written. Call {@link
  * #start()} immediately before calling {@link AudioTrack#play()}. Call {@link #pause()} when
@@ -172,6 +172,7 @@ import java.lang.reflect.Method;
   private int outputPcmFrameSize;
   private int bufferSize;
   @Nullable private AudioTimestampPoller audioTimestampPoller;
+  private boolean applyDolbyPassThroughQuirk; // MIREGO - AMZN_CHANGE_ONELINE
   private int outputSampleRate;
   private boolean needsPassthroughWorkarounds;
   private long bufferSizeUs;
@@ -230,7 +231,7 @@ import java.lang.reflect.Method;
     if (Util.SDK_INT >= 18) {
       try {
         getLatencyMethod = AudioTrack.class.getMethod("getLatency", (Class<?>[]) null);
-      } catch (NoSuchMethodException e) {
+      } catch (Throwable e) { // MIREGO - AMZN_CHANGE_ONELINE: Some legacy devices throw unexpected errors
         // There's no guarantee this method exists. Do nothing.
       }
     }
@@ -254,10 +255,12 @@ import java.lang.reflect.Method;
       boolean isPassthrough,
       @C.Encoding int outputEncoding,
       int outputPcmFrameSize,
-      int bufferSize) {
+      int bufferSize,
+      boolean applyDolbyPassThroughQuirk) { // MIREGO - AMZN_CHANGE_ONELINE
     this.audioTrack = audioTrack;
     this.outputPcmFrameSize = outputPcmFrameSize;
     this.bufferSize = bufferSize;
+    this.applyDolbyPassThroughQuirk = applyDolbyPassThroughQuirk; // MIREGO - AMZN_CHANGE_ONELINE
     audioTimestampPoller = new AudioTimestampPoller(audioTrack);
     outputSampleRate = audioTrack.getSampleRate();
     needsPassthroughWorkarounds = isPassthrough && needsPassthroughWorkarounds(outputEncoding);
@@ -290,7 +293,10 @@ import java.lang.reflect.Method;
   }
 
   public long getCurrentPositionUs(boolean sourceEnded) {
-    if (checkNotNull(this.audioTrack).getPlayState() == PLAYSTATE_PLAYING) {
+    // MIREGO - AMZN_CHANGE_BEGIN
+    // for dolby passthrough case, we don't need to sync sample
+    // params because we don't depend on play head position for timestamp
+    if (checkNotNull(this.audioTrack).getPlayState() == PLAYSTATE_PLAYING && !applyDolbyPassThroughQuirk) {
       maybeSampleSyncParams();
     }
 
@@ -300,7 +306,19 @@ import java.lang.reflect.Method;
     long positionUs;
     AudioTimestampPoller audioTimestampPoller = checkNotNull(this.audioTimestampPoller);
     boolean useGetTimestampMode = audioTimestampPoller.hasAdvancingTimestamp();
-    if (useGetTimestampMode) {
+    // MIREGO - AMZN_CHANGE_START
+    // for dolby passthrough case, we just depend on getTimeStamp API
+    // for audio video synchronization.
+    if (applyDolbyPassThroughQuirk) {
+      boolean audioTimestampSet = audioTimestampPoller.maybePollTimestamp(systemTimeUs, true);
+      if (audioTimestampSet) {
+        positionUs = audioTimestampPoller.getTimestampSystemTimeUs();
+      } else {
+        positionUs = 0;
+      }
+      return positionUs;
+      // MIREGO - AMZN_CHANGE_END
+    } else if (useGetTimestampMode) { // AMZN_CHANGE_END
       // Calculate the speed-adjusted position using the timestamp (which may be in the future).
       long timestampPositionFrames = audioTimestampPoller.getTimestampPositionFrames();
       long timestampPositionUs = sampleCountToDurationUs(timestampPositionFrames, outputSampleRate);
@@ -392,7 +410,7 @@ import java.lang.reflect.Method;
    */
   public boolean mayHandleBuffer(long writtenFrames) {
     @PlayState int playState = checkNotNull(audioTrack).getPlayState();
-    if (needsPassthroughWorkarounds) {
+    if (needsPassthroughWorkarounds && !applyDolbyPassThroughQuirk) { // MIREGO - AMZN_CHANGE_ONELINE
       // An AC-3 audio track continues to play data written while it is paused. Stop writing so its
       // buffer empties. See [Internal: b/18899620].
       if (playState == PLAYSTATE_PAUSED) {
@@ -404,7 +422,7 @@ import java.lang.reflect.Method;
       // A new AC-3 audio track's playback position continues to increase from the old track's
       // position for a short time after is has been released. Avoid writing data until the playback
       // head position actually returns to zero.
-      if (playState == PLAYSTATE_STOPPED && getPlaybackHeadPosition() == 0) {
+      if (playState == PLAYSTATE_STOPPED && getPlaybackHeadPosition() != 0) { // MIREGO - AMZN_CHANGE_ONELINE
         return false;
       }
     }
@@ -460,7 +478,8 @@ import java.lang.reflect.Method;
    */
   public boolean hasPendingData(long writtenFrames) {
     long currentPositionUs = getCurrentPositionUs(/* sourceEnded= */ false);
-    return writtenFrames > durationUsToSampleCount(currentPositionUs, outputSampleRate)
+    return applyDolbyPassThroughQuirk // MIREGO - AMZN_CHANGE_ONELINE
+        || writtenFrames > durationUsToSampleCount(currentPositionUs, outputSampleRate)
         || forceHasPendingData();
   }
 
@@ -492,7 +511,7 @@ import java.lang.reflect.Method;
 
   /**
    * Resets the position tracker. Should be called when the audio track previously passed to {@link
-   * #setAudioTrack(AudioTrack, boolean, int, int, int)} is no longer in use.
+   * #setAudioTrack(AudioTrack, boolean, int, int, int, boolean)} is no longer in use.
    */
   public void reset() {
     resetSyncParams();

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
@@ -19,6 +19,7 @@ import static androidx.media3.common.audio.AudioProcessor.EMPTY_BUFFER;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.common.util.Assertions.checkState;
 import static androidx.media3.common.util.Util.constrainValue;
+import static androidx.media3.common.util.Util.getAudioFormat;
 import static androidx.media3.exoplayer.audio.AudioCapabilities.DEFAULT_AUDIO_CAPABILITIES;
 import static androidx.media3.exoplayer.audio.AudioCapabilities.getCapabilities;
 import static java.lang.Math.max;
@@ -28,6 +29,7 @@ import static java.lang.annotation.ElementType.TYPE_USE;
 import android.content.Context;
 import android.media.AudioDeviceInfo;
 import android.media.AudioFormat;
+import android.media.AudioManager;
 import android.media.AudioTrack;
 import android.media.PlaybackParams;
 import android.media.metrics.LogSessionId;
@@ -59,6 +61,7 @@ import androidx.media3.common.util.UnstableApi;
 import androidx.media3.common.util.Util;
 import androidx.media3.exoplayer.ExoPlayer.AudioOffloadListener;
 import androidx.media3.exoplayer.analytics.PlayerId;
+import androidx.media3.exoplayer.util.AmazonQuirks;
 import androidx.media3.extractor.AacUtil;
 import androidx.media3.extractor.Ac3Util;
 import androidx.media3.extractor.Ac4Util;
@@ -542,6 +545,9 @@ public final class DefaultAudioSink implements AudioSink {
   private long lastFeedElapsedRealtimeMs;
   private boolean offloadDisabledUntilNextConfiguration;
   private boolean isWaitingForOffloadEndOfStreamHandled;
+  // MIREGO - AMZN_CHANGE_BEGIN
+  private static final boolean isLegacyPassthroughQuirkEnabled = AmazonQuirks.isDolbyPassthroughQuirkEnabled();
+  // MIREGO - AMZN_CHANGE_END
   @Nullable private Looper playbackLooper;
 
   @RequiresNonNull("#1.audioProcessorChain")
@@ -586,6 +592,17 @@ public final class DefaultAudioSink implements AudioSink {
   public void setListener(Listener listener) {
     this.listener = listener;
   }
+
+  // MIREGO - AMZN_CHANGE_BEGIN
+  // This API is called from MediaCodecAudioTrackRenderer to skip
+  // calling hasPendingData  to detect if the playback has ended or not since these APIs
+  // always return true and fake the buffering state of audio track.
+  // there is no way for us to depend on the audio track states to decide
+  // if the playback has ended or not.
+  public boolean applyDolbyPassthroughQuirk() {
+    return (configuration.outputMode != OUTPUT_MODE_PCM && isLegacyPassthroughQuirkEnabled);
+  }
+  // MIREGO - AMZN_CHANGE_END
 
   @Override
   public void setPlayerId(@Nullable PlayerId playerId) {
@@ -854,7 +871,8 @@ public final class DefaultAudioSink implements AudioSink {
         /* isPassthrough= */ configuration.outputMode == OUTPUT_MODE_PASSTHROUGH,
         configuration.outputEncoding,
         configuration.outputPcmFrameSize,
-        configuration.bufferSize);
+        configuration.bufferSize,
+        applyDolbyPassthroughQuirk()); // MIREGO - AMZN_CHANGE_ONELINE
     setVolumeInternal();
 
     if (auxEffectInfo.effectId != AuxEffectInfo.NO_AUX_EFFECT_ID) {
@@ -1232,7 +1250,9 @@ public final class DefaultAudioSink implements AudioSink {
       Assertions.checkArgument(outputBuffer == buffer);
     } else {
       outputBuffer = buffer;
-      if (Util.SDK_INT < 21) {
+      // AMZN: we need to copy data to temp buffer in case of dolby passthrough also
+      // irrespective of SDK version.
+      if (Util.SDK_INT < 21 || applyDolbyPassthroughQuirk()) { // MIREGO - AMZN_CHANGE_ONELINE
         int bytesRemaining = buffer.remaining();
         if (preV21OutputBuffer == null || preV21OutputBuffer.length < bytesRemaining) {
           preV21OutputBuffer = new byte[bytesRemaining];
@@ -1245,7 +1265,23 @@ public final class DefaultAudioSink implements AudioSink {
     }
     int bytesRemaining = buffer.remaining();
     int bytesWrittenOrError = 0; // Error if negative
-    if (Util.SDK_INT < 21) { // outputMode == OUTPUT_MODE_PCM.
+
+    // MIREGO - AMZN_CHANGE_BEGIN
+    // for dolby passthrough case, just write into the DolbyPassthroughAudioTrack
+    // since its implementation is different than standard pcm audio track.
+    // The DolbyPassthroughAudioTrack takes care of writing only in play state
+    // and also writes into the track asynchronously. Also, we
+    // cannot depend on playback head position to decide how much more data to write.
+    if (applyDolbyPassthroughQuirk()) {
+      // if there are no free buffers in AudioTrack, the write returns 0, indicating
+      // it did not consume the buffer.
+      bytesWrittenOrError = audioTrack.write(preV21OutputBuffer, preV21OutputBufferOffset, bytesRemaining);
+      if (bytesWrittenOrError > 0) {
+        preV21OutputBufferOffset += bytesWrittenOrError;
+        buffer.position(buffer.position() + bytesWrittenOrError);
+      }
+    } else if (Util.SDK_INT < 21) { // outputMode == OUTPUT_MODE_PCM.
+      // MIREGO - AMZN_CHANGE_END
       // Work out how many bytes we can write without the risk of blocking.
       int bytesToWrite = audioTrackPositionTracker.getAvailableBufferSize(writtenPcmBytes);
       if (bytesToWrite > 0) {
@@ -1380,7 +1416,8 @@ public final class DefaultAudioSink implements AudioSink {
 
   @Override
   public boolean isEnded() {
-    return !isAudioTrackInitialized() || (handledEndOfStream && !hasPendingData());
+    return !isAudioTrackInitialized() || (handledEndOfStream &&
+        (applyDolbyPassthroughQuirk() || !hasPendingData())); // MIREGO - AMZN_CHANGE_ONELINE
   }
 
   @Override
@@ -1966,7 +2003,12 @@ public final class DefaultAudioSink implements AudioSink {
   private void playPendingData() {
     if (!stoppedAudioTrack) {
       stoppedAudioTrack = true;
-      audioTrackPositionTracker.handleEndOfStream(getWrittenFrames());
+      // The audio processors have drained, so drain the underlying audio track.
+      // MIREGO - AMZN_CHANGE_BEGIN
+      if (!applyDolbyPassthroughQuirk()) {
+        audioTrackPositionTracker.handleEndOfStream(getWrittenFrames());
+      }
+      // MIREGO - AMZN_CHANGE_END
       audioTrack.stop();
       bytesUntilNextAvSync = 0;
     }
@@ -2242,6 +2284,12 @@ public final class DefaultAudioSink implements AudioSink {
       return Util.sampleCountToDurationUs(frameCount, outputSampleRate);
     }
 
+    // MIREGO - AMZN_CHANGE_BEGIN
+    public boolean applyDolbyPassthroughQuirk() {
+      return ( outputMode != OUTPUT_MODE_PCM  && isLegacyPassthroughQuirkEnabled);
+    }
+    // MIREGO - AMZN_CHANGE_END
+
     public AudioTrackConfig buildAudioTrackConfig() {
       return new AudioTrackConfig(
           outputEncoding,
@@ -2301,7 +2349,7 @@ public final class DefaultAudioSink implements AudioSink {
     @RequiresApi(29)
     private AudioTrack createAudioTrackV29(AudioAttributes audioAttributes, int audioSessionId) {
       AudioFormat audioFormat =
-          Util.getAudioFormat(outputSampleRate, outputChannelConfig, outputEncoding);
+          getAudioFormat(outputSampleRate, outputChannelConfig, outputEncoding);
       android.media.AudioAttributes audioTrackAttributes =
           getAudioTrackAttributesV21(audioAttributes, tunneling);
 
@@ -2324,36 +2372,73 @@ public final class DefaultAudioSink implements AudioSink {
 
     @RequiresApi(21)
     private AudioTrack createAudioTrackV21(AudioAttributes audioAttributes, int audioSessionId) {
-      return new AudioTrack(
-          getAudioTrackAttributesV21(audioAttributes, tunneling),
-          Util.getAudioFormat(outputSampleRate, outputChannelConfig, outputEncoding),
-          bufferSize,
-          AudioTrack.MODE_STREAM,
-          audioSessionId);
+      // MIREGO - AMZN_CHANGE_BEGIN
+      audioSessionId = audioSessionId != C.AUDIO_SESSION_ID_UNSET ? audioSessionId
+          : AudioManager.AUDIO_SESSION_ID_GENERATE;
+      if (applyDolbyPassthroughQuirk()) {
+        return new DolbyPassthroughAudioTrack(
+            getAudioTrackAttributesV21(audioAttributes, tunneling),
+            getAudioFormat(outputSampleRate, outputChannelConfig, outputEncoding),
+            bufferSize,
+            AudioTrack.MODE_STREAM,
+            audioSessionId);
+      } else {
+        return new AudioTrack(
+            getAudioTrackAttributesV21(audioAttributes, tunneling),
+            getAudioFormat(outputSampleRate, outputChannelConfig, outputEncoding),
+            bufferSize,
+            AudioTrack.MODE_STREAM,
+            audioSessionId);
+
+      }
+      // MIREGO - AMZN_CHANGE_END
     }
 
     @SuppressWarnings("deprecation") // Using deprecated AudioTrack constructor.
     private AudioTrack createAudioTrackV9(AudioAttributes audioAttributes, int audioSessionId) {
       int streamType = Util.getStreamTypeForAudioUsage(audioAttributes.usage);
+      // MIREGO - AMZN_CHANGE_BEGIN
       if (audioSessionId == C.AUDIO_SESSION_ID_UNSET) {
-        return new AudioTrack(
-            streamType,
-            outputSampleRate,
-            outputChannelConfig,
-            outputEncoding,
-            bufferSize,
-            AudioTrack.MODE_STREAM);
+        if (applyDolbyPassthroughQuirk()) {
+          return new DolbyPassthroughAudioTrack(streamType,
+              outputSampleRate,
+              outputChannelConfig,
+              outputEncoding,
+              bufferSize,
+              AudioTrack.MODE_STREAM);
+        }
+        else {
+          return new AudioTrack(
+              streamType,
+              outputSampleRate,
+              outputChannelConfig,
+              outputEncoding,
+              bufferSize,
+              AudioTrack.MODE_STREAM);
+        }
       } else {
         // Re-attach to the same audio session.
-        return new AudioTrack(
-            streamType,
-            outputSampleRate,
-            outputChannelConfig,
-            outputEncoding,
-            bufferSize,
-            AudioTrack.MODE_STREAM,
-            audioSessionId);
+        if (applyDolbyPassthroughQuirk()) {
+          return new DolbyPassthroughAudioTrack(streamType,
+              outputSampleRate,
+              outputChannelConfig,
+              outputEncoding,
+              bufferSize,
+              AudioTrack.MODE_STREAM,
+              audioSessionId);
+        }
+        else {
+          return new AudioTrack(
+              streamType,
+              outputSampleRate,
+              outputChannelConfig,
+              outputEncoding,
+              bufferSize,
+              AudioTrack.MODE_STREAM,
+              audioSessionId);
+        }
       }
+      // MIREGO - AMZN_CHANGE_END
     }
 
     @RequiresApi(21)

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
@@ -2286,7 +2286,7 @@ public final class DefaultAudioSink implements AudioSink {
 
     // MIREGO - AMZN_CHANGE_BEGIN
     public boolean applyDolbyPassthroughQuirk() {
-      return ( outputMode != OUTPUT_MODE_PCM  && isLegacyPassthroughQuirkEnabled);
+      return (outputMode != OUTPUT_MODE_PCM && isLegacyPassthroughQuirkEnabled);
     }
     // MIREGO - AMZN_CHANGE_END
 

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioTrackBufferSizeProvider.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioTrackBufferSizeProvider.java
@@ -220,8 +220,8 @@ public class DefaultAudioTrackBufferSizeProvider
     // Buffer size must not be lower than the AudioTrack min buffer size for this format.
     bufferSize = max(minBufferSizeInBytes, bufferSize);
     // Increase if needed to make sure the buffers contains an integer number of frames.
-    // MIREGO - AMZN_CHANGE_START
-    if(pcmFrameSize > 0){
+    // MIREGO - AMZN_CHANGE_BEGIN
+    if (pcmFrameSize > 0) {
       bufferSize = (bufferSize + pcmFrameSize - 1) / pcmFrameSize * pcmFrameSize;
     }
     return bufferSize;

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioTrackBufferSizeProvider.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioTrackBufferSizeProvider.java
@@ -220,7 +220,12 @@ public class DefaultAudioTrackBufferSizeProvider
     // Buffer size must not be lower than the AudioTrack min buffer size for this format.
     bufferSize = max(minBufferSizeInBytes, bufferSize);
     // Increase if needed to make sure the buffers contains an integer number of frames.
-    return (bufferSize + pcmFrameSize - 1) / pcmFrameSize * pcmFrameSize;
+    // MIREGO - AMZN_CHANGE_START
+    if(pcmFrameSize > 0){
+      bufferSize = (bufferSize + pcmFrameSize - 1) / pcmFrameSize * pcmFrameSize;
+    }
+    return bufferSize;
+    // MIREGO - AMZN_CHANGE_END
   }
 
   /** Returns the buffer size for playback at 1x speed. */

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DolbyPassthroughAudioTrack.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DolbyPassthroughAudioTrack.java
@@ -66,6 +66,7 @@ public final class DolbyPassthroughAudioTrack extends AudioTrack {
     super(attributes, format, bufferSizeInBytes, mode, sessionId);
     initialize();
   }
+
   public DolbyPassthroughAudioTrack(int streamType, int sampleRateInHz,
       int channelConfig, int audioFormat,
       int bufferSizeInBytes, int mode)
@@ -84,7 +85,7 @@ public final class DolbyPassthroughAudioTrack extends AudioTrack {
   }
 
   private void initialize() {
-    Log.i( TAG, "initialize" );
+    Log.i(TAG, "initialize");
     trackHandlerGate = new ConditionVariable(true);
     trackHandlerThread = new HandlerThread(TRACK_HANDLER_THREAD_NAME);
     pendingWriteSem = new Semaphore(BUFFER_COUNT);
@@ -96,7 +97,7 @@ public final class DolbyPassthroughAudioTrack extends AudioTrack {
      */
     trackHandler = new Handler(trackHandlerThread.getLooper()) {
       public void handleMessage(Message msg) {
-        switch(msg.what) {
+        switch (msg.what) {
           case MSG_WRITE_TO_TRACK: {
             int size = msg.arg1;
             int bufferIndex = msg.arg2;

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DolbyPassthroughAudioTrack.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DolbyPassthroughAudioTrack.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright (C) 2014 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.media3.exoplayer.audio;
+
+import android.media.*;
+import android.os.Build;
+import android.os.ConditionVariable;
+import android.os.HandlerThread;
+import android.os.Handler;
+import android.os.Message;
+import android.util.Log;
+
+import androidx.annotation.RequiresApi;
+import java.util.concurrent.Semaphore;
+
+/**
+ * This class extends to an {@link android.media.AudioTrack} and handles
+ * asynchronous writes to underlying DirectTrack implementation on Fire TV
+ * family of devices to support Dolby Pass through playback.
+ * APIs needs to be called from single thread.
+ */
+
+public final class DolbyPassthroughAudioTrack extends AudioTrack {
+
+  private final String TAG = DolbyPassthroughAudioTrack.class.getSimpleName();
+
+  // handle thread related
+  private HandlerThread trackHandlerThread = null;
+  private static final String TRACK_HANDLER_THREAD_NAME = "dolbyTrackHandlerThread";
+  private Handler trackHandler = null;
+  private ConditionVariable trackHandlerGate = null;
+
+  // handler messages
+  private static final int MSG_WRITE_TO_TRACK = 1;
+  private static final int MSG_PAUSE_TRACK = 2;
+  private static final int MSG_PLAY_TRACK = 3;
+  private static final int MSG_FLUSH_TRACK = 4;
+  private static final int MSG_STOP_TRACK = 5;
+  private static final int MSG_RELEASE_TRACK = 6;
+
+  // required for handling buffers
+  // we allocate fixed number of buffers and cycle through them
+  private static final int BUFFER_COUNT = 2;
+  // Counting Semaphore for tracking ping/pong buffers
+  private Semaphore pendingWriteSem = null;
+  private byte[][] audioBuffer = null;
+  // Next free buffer to be used to copy incoming writes
+  private int nextBufferIndex = 0;
+
+  @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+  public DolbyPassthroughAudioTrack(AudioAttributes attributes, AudioFormat format, int bufferSizeInBytes,
+      int mode, int sessionId) {
+    super(attributes, format, bufferSizeInBytes, mode, sessionId);
+    initialize();
+  }
+  public DolbyPassthroughAudioTrack(int streamType, int sampleRateInHz,
+      int channelConfig, int audioFormat,
+      int bufferSizeInBytes, int mode)
+      throws IllegalArgumentException {
+    this(streamType, sampleRateInHz, channelConfig, audioFormat,
+        bufferSizeInBytes, mode, 0);
+  }
+
+  public DolbyPassthroughAudioTrack(int streamType, int sampleRateInHz,
+      int channelConfig, int audioFormat,
+      int bufferSizeInBytes, int mode, int sessionId)
+      throws IllegalArgumentException {
+    super(streamType, sampleRateInHz, channelConfig, audioFormat,
+        bufferSizeInBytes, mode, sessionId);
+    initialize();
+  }
+
+  private void initialize() {
+    Log.i( TAG, "initialize" );
+    trackHandlerGate = new ConditionVariable(true);
+    trackHandlerThread = new HandlerThread(TRACK_HANDLER_THREAD_NAME);
+    pendingWriteSem = new Semaphore(BUFFER_COUNT);
+    audioBuffer = new byte[BUFFER_COUNT][];
+
+    trackHandlerThread.start();
+    /**
+     * This handler thread serializes all the base audio track APIs.
+     */
+    trackHandler = new Handler(trackHandlerThread.getLooper()) {
+      public void handleMessage(Message msg) {
+        switch(msg.what) {
+          case MSG_WRITE_TO_TRACK: {
+            int size = msg.arg1;
+            int bufferIndex = msg.arg2;
+            //Log.v("writing to track : size = " + size +
+            //  " bufferIndex = " + bufferIndex);
+            DolbyPassthroughAudioTrack.super.write( audioBuffer[ bufferIndex ], 0, size );
+            //log.v("writing to  track  done");
+            pendingWriteSem.release();
+            break;
+          }
+          case MSG_PAUSE_TRACK : {
+            Log.i(TAG, "pausing track");
+            DolbyPassthroughAudioTrack.super.pause();
+            trackHandlerGate.open();
+            break;
+          }
+          case MSG_PLAY_TRACK : {
+            Log.i(TAG, "playing track");
+            DolbyPassthroughAudioTrack.super.play();
+            trackHandlerGate.open();
+            break;
+          }
+          case MSG_FLUSH_TRACK : {
+            Log.i(TAG, "flushing track");
+            DolbyPassthroughAudioTrack.super.flush();
+            trackHandlerGate.open();
+            break;
+          }
+          case MSG_STOP_TRACK : {
+            Log.i(TAG, "stopping track");
+            DolbyPassthroughAudioTrack.super.stop();
+            trackHandlerGate.open();
+            break;
+          }
+          case MSG_RELEASE_TRACK : {
+            Log.i(TAG, "releasing track");
+            if (DolbyPassthroughAudioTrack.super.getPlayState() != PLAYSTATE_STOPPED) {
+              Log.i(TAG, "not in stopped state...stopping");
+              DolbyPassthroughAudioTrack.super.stop();
+            }
+            DolbyPassthroughAudioTrack.super.release();
+            trackHandlerGate.open();
+            break;
+          }
+          default: {
+            Log.w(TAG, "unknown message..ignoring!!!");
+            break;
+          }
+        }
+      }
+    };
+  }
+
+  /**
+   * Play will block until previous messages to handler Thread
+   * are executed.
+   * We need to serialize play, write, pause and release because otherwise,
+   * base audio track  will misbehave.
+   */
+  @Override
+  public void play()
+      throws IllegalStateException {
+    Log.i(TAG, "play");
+    trackHandlerGate.close();
+    Message msg = trackHandler.obtainMessage(MSG_PLAY_TRACK);
+    //Log.d(TAG, "Sending play to DirectTrack handler thread");
+    trackHandler.sendMessage(msg);
+    trackHandlerGate.block();
+    //Log.d(TAG, "DirectTrack Play done");
+  }
+
+  /**
+   * Pause will block until previous (possibly write) messages to handler Thread
+   * are executed.
+   * We need to serialize play, write and pause because otherwise,
+   * base audio track  will misbehave.
+   */
+  @Override
+  public void pause()
+      throws IllegalStateException {
+    Log.i(TAG, "pause");
+    trackHandlerGate.close();
+    Message msg = trackHandler.obtainMessage(MSG_PAUSE_TRACK);
+    //log.d("Sending pause directtrack handler thread");
+    trackHandler.sendMessage(msg);
+    trackHandlerGate.block();
+    //log.d("Pausing Direct Track Done");
+  }
+
+  /**
+   * FLush will block until previous (possibly write) messages to handler Thread
+   * are executed.
+   */
+  @Override
+  public void flush()
+      throws IllegalStateException {
+    Log.i(TAG, "flush");
+    trackHandlerGate.close();
+    Message msg = trackHandler.obtainMessage(MSG_FLUSH_TRACK);
+    //log.d("Sending flush Directtrack handler thread");
+    trackHandler.sendMessage(msg);
+    trackHandlerGate.block();
+    //log.d("Flushing Direct Track Done");
+  }
+
+  /**
+   * Stop will block until previous (possibly write) messages to handler Thread
+   * are executed.
+   */
+  @Override
+  public void stop()
+      throws IllegalStateException {
+    Log.i(TAG, "stop");
+    if (getPlayState() == PLAYSTATE_STOPPED) {
+      Log.i(TAG, "already in stopped state");
+      return;
+    }
+    trackHandlerGate.close();
+    Message msg = trackHandler.obtainMessage(MSG_STOP_TRACK);
+    //log.d("Sending stop Directtrack handler thread");
+    trackHandler.sendMessage(msg);
+    trackHandlerGate.block();
+    //log.d("Stopping Direct Track Done");
+  }
+
+  /**
+   * Queues up Write messages to the handler thread. The
+   * writes happen only when the base audio track is in playing state.
+   * We also use {@link DolbyPassthroughAudioTrack#BUFFER_COUNT} number
+   * of buffers in a cyclic manner.
+   */
+  @Override
+  public int write(byte[] audioData, int offsetInBytes, int sizeInBytes) {
+    if (getPlayState() != android.media.AudioTrack.PLAYSTATE_PLAYING ) {
+      Log.w(TAG, "not in play state..not writing buffer now...");
+      return 0;
+    }
+    if (!pendingWriteSem.tryAcquire()) {
+      //Log.v(TAG, "pending writes... not writing buffer now");
+      return 0;
+    }
+    if (audioBuffer[nextBufferIndex] == null ||
+        audioBuffer[nextBufferIndex].length < sizeInBytes) {
+      //Log.v("Allocating buffer index = " + nextBufferIndex +
+      //       "size = " + sizeInBytes);
+      audioBuffer[nextBufferIndex] = new byte[sizeInBytes];
+    }
+    System.arraycopy(audioData,offsetInBytes,audioBuffer[nextBufferIndex],0,sizeInBytes);
+    Message msg = trackHandler.obtainMessage(MSG_WRITE_TO_TRACK,
+        sizeInBytes,
+        nextBufferIndex);
+    //log.v("Sending buffer to directtrack handler thread");
+    trackHandler.sendMessage(msg);
+    nextBufferIndex = ((nextBufferIndex + 1) % BUFFER_COUNT);
+
+    return sizeInBytes;
+  }
+
+  /**
+   * Release will block until previous messages to handler Thread
+   * are executed.
+   * We need to serialize play, write, pause and release because otherwise,
+   * base audio track  will misbehave.
+   */
+  @Override
+  public void release() {
+    Log.i(TAG, "release");
+    trackHandlerGate.close();
+    Message msg = trackHandler.obtainMessage(MSG_RELEASE_TRACK);
+    //log.d("Sending release directtrack handler thread");
+    trackHandler.sendMessage(msg);
+    trackHandlerGate.block();
+
+    trackHandlerThread.quit();
+    trackHandlerThread = null;
+    trackHandler = null;
+    trackHandlerGate = null;
+    pendingWriteSem = null;
+    audioBuffer = null;
+    //log.d("Release track done");
+  }
+}

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/MediaCodecAudioRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/MediaCodecAudioRenderer.java
@@ -64,6 +64,7 @@ import androidx.media3.exoplayer.mediacodec.MediaCodecRenderer;
 import androidx.media3.exoplayer.mediacodec.MediaCodecSelector;
 import androidx.media3.exoplayer.mediacodec.MediaCodecUtil;
 import androidx.media3.exoplayer.mediacodec.MediaCodecUtil.DecoderQueryException;
+import androidx.media3.exoplayer.util.AmazonQuirks;
 import androidx.media3.extractor.VorbisUtil;
 import com.google.common.collect.ImmutableList;
 import java.nio.ByteBuffer;
@@ -403,7 +404,7 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
     if (format.sampleMimeType == null) {
       return ImmutableList.of();
     }
-    if (audioSink.supportsFormat(format)) {
+    if (audioSink.supportsFormat(format) && AmazonQuirks.useDefaultPassthroughDecoder()) { // MIREGO - AMZN_CHANGE_ONELINE) {
       // The format is supported directly, so a codec is only needed for decryption.
       @Nullable MediaCodecInfo codecInfo = MediaCodecUtil.getDecryptOnlyDecoderInfo();
       if (codecInfo != null) {
@@ -562,7 +563,15 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
         pcmEncoding = mediaFormat.getInteger(MediaFormat.KEY_PCM_ENCODING);
       } else if (mediaFormat.containsKey(VIVO_BITS_PER_SAMPLE_KEY)) {
         pcmEncoding = Util.getPcmEncoding(mediaFormat.getInteger(VIVO_BITS_PER_SAMPLE_KEY));
-      } else {
+      } // MIREGO - AMZN_CHANGE_BEGIN
+      else if (AmazonQuirks.isAmazonDevice()) {
+        // In Amazon Devices, some platform dolby decoders may output mime types depending on the
+        // audio capabilities of the connected device and Dolby settings. So, as a general rule, if
+        // platform decoder is being used instead of OMX.google.raw.decoder, need to
+        // configure audio track based on the output mime type returned by the media codec.
+        pcmEncoding = MimeTypes.getEncoding(mediaFormat.getString(MediaFormat.KEY_MIME), format.codecs);
+      } // MIREGO - AMZN_CHANGE_END
+      else {
         // If the format is anything other than PCM then we assume that the audio decoder will
         // output 16-bit PCM.
         pcmEncoding = C.ENCODING_PCM_16BIT;

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/MediaCodecAudioRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/MediaCodecAudioRenderer.java
@@ -404,7 +404,7 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
     if (format.sampleMimeType == null) {
       return ImmutableList.of();
     }
-    if (audioSink.supportsFormat(format) && AmazonQuirks.useDefaultPassthroughDecoder()) { // MIREGO - AMZN_CHANGE_ONELINE) {
+    if (audioSink.supportsFormat(format) && AmazonQuirks.useDefaultPassthroughDecoder()) { // MIREGO - AMZN_CHANGE_ONELINE
       // The format is supported directly, so a codec is only needed for decryption.
       @Nullable MediaCodecInfo codecInfo = MediaCodecUtil.getDecryptOnlyDecoderInfo();
       if (codecInfo != null) {

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/util/AmazonQuirks.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/util/AmazonQuirks.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2014 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.media3.exoplayer.util;
+
+import android.os.Build;
+import android.util.Log;
+
+public final class AmazonQuirks {
+
+    //ordering of the static initializations is important.
+    private static final String TAG = AmazonQuirks.class.getSimpleName();
+    private static final String FIRETV_GEN1_DEVICE_MODEL       = "AFTB";
+    private static final String FIRETV_GEN2_DEVICE_MODEL       = "AFTS";
+    private static final String FIRETV_STICK_DEVICE_MODEL      = "AFTM";
+    private static final String FIRETV_STICK_GEN2_DEVICE_MODEL = "AFTT";
+    private static final String KINDLE_TABLET_DEVICE_MODEL     = "KF";
+    private static final String AMAZON                         = "Amazon";
+
+    private static final String DEVICEMODEL  = Build.MODEL;
+    private static final String MANUFACTURER = Build.MANUFACTURER;
+
+    //caching
+    private static final boolean isAmazonDevice;
+    private static final boolean isFireTVGen1;
+    private static final boolean isFireTVStick;
+    private static final boolean isFireTVGen2;
+
+    // This static block must be the last
+    //INIT ORDERING IS IMPORTANT IN THIS BLOCK!
+    static {
+        isAmazonDevice = MANUFACTURER.equalsIgnoreCase(AMAZON);
+        isFireTVGen1   = isAmazonDevice && DEVICEMODEL.equalsIgnoreCase(FIRETV_GEN1_DEVICE_MODEL);
+        isFireTVGen2   = isAmazonDevice && DEVICEMODEL.equalsIgnoreCase(FIRETV_GEN2_DEVICE_MODEL);
+        isFireTVStick  = isAmazonDevice && DEVICEMODEL.equalsIgnoreCase(FIRETV_STICK_DEVICE_MODEL);
+    }
+
+    private AmazonQuirks(){}
+
+    public static boolean isDolbyPassthroughQuirkEnabled() {
+        // Sets dolby passthrough quirk for Amazon Fire TV (Gen 1) Family
+        return isFireTVGen1Family();
+    }
+
+    public static boolean isAmazonDevice(){
+        return isAmazonDevice;
+    }
+
+    public static boolean isFireTVGen1Family() {
+        return isFireTVGen1 || isFireTVStick;
+    }
+
+    public static boolean isFireTVGen2() {
+        return isFireTVGen2;
+    }
+
+    // We assume that this function is called only for supported
+    // passthrough mimetypes such as AC3, EAC3 etc
+    public static boolean useDefaultPassthroughDecoder() {
+        //Use platform decoder only for
+        // - FireTV Gen1
+        // - FireTV Stick
+        if (isFireTVGen1Family()) {
+            Log.i(TAG, "Using platform Dolby decoder");
+            return false;
+        }
+
+        Log.i(TAG, "Using default Dolby pass-through decoder");
+        return true;
+    }
+}


### PR DESCRIPTION
## Description

This PR bring a fix made by Amazon on their [exoplayer-amazon-port](https://github.com/amzn/exoplayer-amazon-port/commit/615d7ff5e8d2b0150120bc7f1f6861e1f3cc7e79). 

## Original description
This is an upmerge of ExoPlayer v1 changes to ExoPlayer V2. See FTVPI-5 for the original issue.

[Problem]
Dolby passthrough audio does not work on Fire TV family of devices.

[Root cause]
FireTV supports a special DirectTrack that is used to render dolby audio. This audio track is created internally when the encoding is ENCODING_AC3 or ENCODING_EAC3. These AudioFormats are custom values because up untill Lollipop release Android did not support Dolby Audio Format.

Additionally, the implementation of Audio Track for dolby encoding format does not strictly adher to the expected behaviour of Android's AudioTrack API.

 1. getPlaybackHeadPosition API is not implemented for DirectTrack. ExoPlayer depends heavily on playbackHeadPosition for audio timestamp calculation. In several places, the playbackHeadPosition is used to calculate the number of frames assuming its PCM data. This is not right for passthrough dolby data.

 2. The write calls are blocking and sometimes take longer time to return.

 3. It does not honor play API i.e even without calling play, the writes starts playing some data. Which means, we cannot have buffer build up in audioTrack like PCM case.

[Solution]
Firstly, we use the custom encoding format for Fire TV family of devices to create the right AudioTrack to support dolby passthrough playback.

Then we solve the AudioTrack related issues as follows:

1. We remove the dependency on playbackHeadPosition for timestamp calculation for dolby passthrough case.

2. We implement a class DolbyPassthroughAudioTrack that extends the AudioTrack of Android to handle the write, pause, play and release APIs asynchronously.

3. We do not write into AudioTrack if it is not in playing state.We modify hasPendingData behaviour to return true even though we have not written any data to the AudioTrack in paused state.

Note: This change is enabled only for Fire TV family of devices.

[Tests]
Tested dolby passthrough playback, seek and audio/video sync etc in Fire TV and Fire TV stick (forced dolby over HDMI and used dolby supported TV).

cr: https://code.amazon.com/reviews/CR-91907190