### PR TITLE
MMSW-13526: Enable async mode by default for FTVE devices

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/DefaultRenderersFactory.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/DefaultRenderersFactory.java
@@ -110,7 +110,7 @@ public class DefaultRenderersFactory implements RenderersFactory {
    */
   public DefaultRenderersFactory(Context context) {
     this.context = context;
-    codecAdapterFactory = new DefaultMediaCodecAdapterFactory();
+    codecAdapterFactory = new DefaultMediaCodecAdapterFactory(context); // MIREGO - AMZN_CHANGE_ONELINE
     extensionRendererMode = EXTENSION_RENDERER_MODE_OFF;
     allowedVideoJoiningTimeMs = DEFAULT_ALLOWED_VIDEO_JOINING_TIME_MS;
     mediaCodecSelector = MediaCodecSelector.DEFAULT;

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/DefaultMediaCodecAdapterFactory.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/DefaultMediaCodecAdapterFactory.java
@@ -17,6 +17,7 @@ package androidx.media3.exoplayer.mediacodec;
 
 import static java.lang.annotation.ElementType.TYPE_USE;
 
+import android.content.Context;
 import androidx.annotation.IntDef;
 import androidx.media3.common.MimeTypes;
 import androidx.media3.common.util.Log;
@@ -53,12 +54,20 @@ public final class DefaultMediaCodecAdapterFactory implements MediaCodecAdapter.
 
   private static final String TAG = "DMCodecAdapterFactory";
 
+  private final Context context; // MIREGO - AMZN_CHANGE_ONELINE
   private @Mode int asynchronousMode;
   private boolean enableSynchronizeCodecInteractionsWithQueueing;
 
+  // MIREGO - AMZN_CHANGE_BEGIN
   public DefaultMediaCodecAdapterFactory() {
+    this(null);
+  }
+
+  public DefaultMediaCodecAdapterFactory(Context context) {
+    this.context = context;
     asynchronousMode = MODE_DEFAULT;
   }
+  // MIREGO - AMZN_CHANGE_END
 
   /**
    * Forces this factory to always create {@link AsynchronousMediaCodecAdapter} instances, provided
@@ -99,9 +108,17 @@ public final class DefaultMediaCodecAdapterFactory implements MediaCodecAdapter.
   @Override
   public MediaCodecAdapter createAdapter(MediaCodecAdapter.Configuration configuration)
       throws IOException {
+    // MIREGO - AMZN_CHANGE_BEGIN
+    boolean isFireTvSmart = false;
+    if(context != null) {
+      isFireTvSmart = context.getPackageManager().hasSystemFeature("com.amazon.hardware.tv_screen");
+    }
+
     if (Util.SDK_INT >= 23
         && (asynchronousMode == MODE_ENABLED
-            || (asynchronousMode == MODE_DEFAULT && Util.SDK_INT >= 31))) {
+            || (asynchronousMode == MODE_DEFAULT && Util.SDK_INT >= 31)
+            || (asynchronousMode == MODE_DEFAULT && isFireTvSmart && Util.SDK_INT >= 28))) {
+      // MIREGO - AMZN_CHANGE_END
       int trackType = MimeTypes.getTrackType(configuration.format.sampleMimeType);
       Log.i(
           TAG,


### PR DESCRIPTION
This PR bring a fix made by Amazon on their [exoplayer-amazon-port](https://github.com/amzn/exoplayer-amazon-port/commit/ebceee08c6ec0218cd89ffdd867327f44750bffe).

## Original description
[Problem]
There are frame drops and performance issues with 60fps content on some Amazon SmartTv (FTVE) devices.

[Solution]
We identified that switching the MediaCodec APIs to asynchronous buffer queueing mode improves the performance and reduces frame drops. We enable async mode by default for FTVE devices with API level >= 28. Developers still have the option to disable async mode with DefaultRenderersFactory.forceDisableMediaCodecAsynchronousQueueing() if they wish to do so.

cr: https://code.amazon.com/reviews/CR-92572712