### PR TITLE
Make addTransferListener() non final

### DIFF
--- a/libraries/datasource/src/main/java/androidx/media3/datasource/BaseDataSource.java
+++ b/libraries/datasource/src/main/java/androidx/media3/datasource/BaseDataSource.java
@@ -50,6 +50,7 @@ public abstract class BaseDataSource implements DataSource {
 
   @UnstableApi
   @Override
+  // MIREGO: removed final
   public void addTransferListener(TransferListener transferListener) {
     checkNotNull(transferListener);
     if (!listeners.contains(transferListener)) {

--- a/libraries/datasource/src/main/java/androidx/media3/datasource/BaseDataSource.java
+++ b/libraries/datasource/src/main/java/androidx/media3/datasource/BaseDataSource.java
@@ -50,7 +50,7 @@ public abstract class BaseDataSource implements DataSource {
 
   @UnstableApi
   @Override
-  public final void addTransferListener(TransferListener transferListener) {
+  public void addTransferListener(TransferListener transferListener) {
     checkNotNull(transferListener);
     if (!listeners.contains(transferListener)) {
       listeners.add(transferListener);


### PR DESCRIPTION
We need to be able to override that function to implement a proxy okhttpDataSource that will allow us to throttle the http transfers to properly simulate bad network conditions.