### PR TITLE
Additional error reporting (AudioSink write + AudioTrackPositionTracker reset delay)

### DIFF
--- a/libraries/common/src/main/java/androidx/media3/common/PlaybackException.java
+++ b/libraries/common/src/main/java/androidx/media3/common/PlaybackException.java
@@ -232,6 +232,12 @@ public class PlaybackException extends Exception implements Bundleable {
   /** MIREGO: Caused by the audio and video being out of sync */
   public static final int ERROR_CODE_AUDIO_VIDEO_DESYNC = 5902;
 
+  /** MIREGO: Caused by the audio sink returning an error on write */
+  public static final int ERROR_CODE_AUDIO_SINK_WRITE = 5903;
+
+  /** MIREGO: Caused by a long delay before the stopped audio track position is reset (potential cause of stuck playback) */
+  public static final int ERROR_CODE_AUDIO_WAITING_FOR_HEAD_POSITION_RESET = 5904;
+  
   // DRM errors (6xxx).
 
   /** Caused by an unspecified error related to DRM protection. */

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
@@ -47,6 +47,7 @@ import androidx.media3.common.AuxEffectInfo;
 import androidx.media3.common.C;
 import androidx.media3.common.Format;
 import androidx.media3.common.MimeTypes;
+import androidx.media3.common.PlaybackException;
 import androidx.media3.common.PlaybackParameters;
 import androidx.media3.common.audio.AudioProcessingPipeline;
 import androidx.media3.common.audio.AudioProcessor;
@@ -1318,8 +1319,8 @@ public final class DefaultAudioSink implements AudioSink {
     if (bytesWrittenOrError < 0) {
       int error = bytesWrittenOrError;
 
-      // MIREGO
-      Log.v(Log.LOG_LEVEL_VERBOSE2, TAG, "writeBuffer error: %d", error);
+      // MIREGO error reporting
+      Log.e(TAG, new PlaybackException("DefaultAudioSink write error " + bytesWrittenOrError, new RuntimeException(), PlaybackException.ERROR_CODE_AUDIO_SINK_WRITE));
 
       // Treat a write error on a previously successful offload channel as recoverable
       // without disabling offload. Offload will be disabled if offload channel was not successfully

--- a/libraries/exoplayer_dash/src/main/java/androidx/media3/exoplayer/dash/manifest/DashManifestParser.java
+++ b/libraries/exoplayer_dash/src/main/java/androidx/media3/exoplayer/dash/manifest/DashManifestParser.java
@@ -594,10 +594,11 @@ public class DashManifestParser extends DefaultHandler
             data = PsshAtomUtil.buildPsshAtom(C.COMMON_PSSH_UUID, defaultKids, null);
             uuid = C.COMMON_PSSH_UUID;
           } else {
-            Log.w(
+            // MIREGO disabling log. It's not an issue, and it's making too much noise in our logs
+/*            Log.w(
                 TAG,
                 "Ignoring <ContentProtection> with schemeIdUri=\"urn:mpeg:dash:mp4protection:2011\""
-                    + " (ClearKey) due to missing required default_KID attribute.");
+                    + " (ClearKey) due to missing required default_KID attribute.");*/
           }
           break;
         case "urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95":


### PR DESCRIPTION
We have some issues in production that we can't reproduce. More error reporting (resulting in crashlytics non-fatal events) will help by hopefully getting relevant info, or to rule out some potential causes.

This PR reports 2 additional errors to the app:
- AudioSink write error
- Delay waiting for the positon reset after a stop

Also, silenced a useless warning that is flooding our logs a little bit.