### PR TITLE
Fix reset of lastRender and skipCount (logs + non-fatals)

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -1491,12 +1491,6 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer implements Video
         dropOutputBuffer(codec, bufferIndex, presentationTimeUs);
       }
       updateVideoFrameProcessingOffsetCounters(earlyUs);
-
-      // MIREGO BEGIN
-      skipCount = 0;
-      lastRender = systemTimeNs / 1000;
-      // MIREGO END
-
       return true;
     } else if (lastRender != 0){ // MIREGO ADDED else block
       skipCount++;
@@ -1547,6 +1541,12 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer implements Video
           renderOutputBufferV21(codec, bufferIndex, presentationTimeUs, adjustedReleaseTimeNs);
         }
         updateVideoFrameProcessingOffsetCounters(earlyUs);
+
+        // MIREGO BEGIN
+        skipCount = 0;
+        lastRender = systemTimeNs / 1000;
+        // MIREGO END
+        
         lastFrameReleaseTimeNs = adjustedReleaseTimeNs;
         return true;
       }


### PR DESCRIPTION
When we merged all of our changes in the new ExoPlayer fork, a small block of code was merged into the wrong code block. It results in some of our counters not resetting properly when we render a frame, which means we can flood the logcat with false errors with the right log level.

This PR fixes moves back the reset where it belongs.