### PR TITLE
Fix NTP timeout adding 10s to the VST

### DIFF
--- a/libraries/common/src/main/java/androidx/media3/common/PlaybackException.java
+++ b/libraries/common/src/main/java/androidx/media3/common/PlaybackException.java
@@ -237,7 +237,10 @@ public class PlaybackException extends Exception implements Bundleable {
 
   /** MIREGO: Caused by a long delay before the stopped audio track position is reset (potential cause of stuck playback) */
   public static final int ERROR_CODE_AUDIO_WAITING_FOR_HEAD_POSITION_RESET = 5904;
-  
+
+  /** MIREGO: Caused by a network error trying to get time from the NTP server */
+  public static final int ERROR_CODE_NTP = 5905;
+
   // DRM errors (6xxx).
 
   /** Caused by an unspecified error related to DRM protection. */
@@ -366,6 +369,18 @@ public class PlaybackException extends Exception implements Bundleable {
         return "ERROR_CODE_VIDEO_FRAME_PROCESSOR_INIT_FAILED";
       case ERROR_CODE_VIDEO_FRAME_PROCESSING_FAILED:
         return "ERROR_CODE_VIDEO_FRAME_PROCESSING_FAILED";
+      // MIREGO: added our custom error codes
+      case ERROR_CODE_AUDIO_TRACK_INCONSISTENT_SAMPLE_RATE:
+        return "ERROR_CODE_AUDIO_TRACK_INCONSISTENT_SAMPLE_RATE";
+      case ERROR_CODE_AUDIO_VIDEO_DESYNC:
+        return "ERROR_CODE_AUDIO_VIDEO_DESYNC";
+      case ERROR_CODE_AUDIO_SINK_WRITE:
+        return "ERROR_CODE_AUDIO_SINK_WRITE";
+      case ERROR_CODE_AUDIO_WAITING_FOR_HEAD_POSITION_RESET:
+        return "ERROR_CODE_AUDIO_WAITING_FOR_HEAD_POSITION_RESET";
+      case ERROR_CODE_NTP:
+        return "ERROR_CODE_NTP";
+
       default:
         if (errorCode >= CUSTOM_ERROR_CODE_BASE) {
           return "custom error code";

--- a/libraries/common/src/main/java/androidx/media3/common/util/Util.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/Util.java
@@ -177,6 +177,7 @@ public final class Util {
   public static int audioVideoDeltaToLogErrorMs = 750;
   public static boolean shouldIgnoreCodecFpsLimitForResolution = false; // MIREGO ADDED
   public static boolean useDifferentAudioSessionIdForTunneling = false; // MIREGO ADDED
+  public static int ntpTimeoutMs = 5000; // MIREGO ADDED
 
   /** An empty long array. */
   @UnstableApi public static final long[] EMPTY_LONG_ARRAY = new long[0];

--- a/libraries/datasource/src/main/java/androidx/media3/datasource/BaseDataSource.java
+++ b/libraries/datasource/src/main/java/androidx/media3/datasource/BaseDataSource.java
@@ -50,8 +50,7 @@ public abstract class BaseDataSource implements DataSource {
 
   @UnstableApi
   @Override
-  // MIREGO: removed final
-  public void addTransferListener(TransferListener transferListener) {
+  public final void addTransferListener(TransferListener transferListener) {
     checkNotNull(transferListener);
     if (!listeners.contains(transferListener)) {
       listeners.add(transferListener);


### PR DESCRIPTION
We have customers who consistently fail to start live playback.
This was caused by a network issue in ipv6 preventing them to connect to the NTP server. The timeout was 10s, which was making them hit the playback start timeout (also 10s).

This PR:
- Makes NTP timeout customizable (default 5s)
- Forces ipv4 for NTP
- Reports NTP error to app
- Adds missing custom error strings

Also:
- Undo useless change in BaseDataSource