### PR TITLE
Add a way to not ignore performance points for resolution and frame rate

### DIFF
--- a/libraries/common/src/main/java/androidx/media3/common/util/Util.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/Util.java
@@ -181,6 +181,7 @@ public final class Util {
   public static int timeSinceLastVideoRenderToLogErrorMs = 1000;
   public static int audioVideoDeltaToLogErrorMs = 750;
   public static boolean shouldIgnoreCodecFpsLimitForResolution = false; // MIREGO ADDED
+  public static boolean doNotIgnorePerformancePointsForResolutionAndFrameRate = false; // MIREGO ADDED
   public static boolean useDifferentAudioSessionIdForTunneling = false; // MIREGO ADDED
   public static int ntpTimeoutMs = 5000; // MIREGO ADDED
 

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecPerformancePointCoverageProvider.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecPerformancePointCoverageProvider.java
@@ -139,6 +139,11 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
         // The same check as below is tested in CTS and we should get reliable results from API 35.
         return false;
       }
+
+      // MIREGO added to select devices on which we do not want to ignore the performance points
+      if (Util.doNotIgnorePerformancePointsForResolutionAndFrameRate) {
+        return false;
+      }
       try {
         Format formatH264 = new Format.Builder().setSampleMimeType(MimeTypes.VIDEO_H264).build();
         // Null check required to pass RequiresNonNull annotation on getDecoderInfosSoftMatch.


### PR DESCRIPTION
In https://github.com/androidx/media/commit/3521ccda9be020419e966308f985fa899b083a45, a fallback was added when there is no coverage for 720p 60 FPS. That introduced performance issues on several device models that are now dropping 15-40 frames / sec in Live playback (depending on the model). That's because they used to stay at a lower resolution/framerate, and are now trying to playback 720P 60 FPS, but they struggle to do so.
This PR will allow us to disable the fallback on the identified device models. So they will revert to using the lower fps track.