### PR TITLE
Do not ignore performance points 2

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecInfo.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecInfo.java
@@ -31,6 +31,7 @@ import static androidx.media3.exoplayer.DecoderReuseEvaluation.REUSE_RESULT_YES_
 import static androidx.media3.exoplayer.DecoderReuseEvaluation.REUSE_RESULT_YES_WITH_RECONFIGURATION;
 import static androidx.media3.exoplayer.mediacodec.MediaCodecPerformancePointCoverageProvider.COVERAGE_RESULT_NO;
 import static androidx.media3.exoplayer.mediacodec.MediaCodecPerformancePointCoverageProvider.COVERAGE_RESULT_YES;
+import static androidx.media3.exoplayer.mediacodec.MediaCodecPerformancePointCoverageProvider.COVERAGE_RESULT_NO_PERFORMANCE_POINTS_UNSUPPORTED;
 
 import android.graphics.Point;
 import android.media.MediaCodec;
@@ -537,6 +538,12 @@ public final class MediaCodecInfo {
       int evaluation =
           MediaCodecPerformancePointCoverageProvider.areResolutionAndFrameRateCovered(
               videoCapabilities, width, height, frameRate);
+
+      // MIREGO added support for doNotIgnorePerformancePointsForResolutionAndFrameRate
+      if (evaluation == COVERAGE_RESULT_NO_PERFORMANCE_POINTS_UNSUPPORTED && Util.doNotIgnorePerformancePointsForResolutionAndFrameRate) {
+        evaluation = COVERAGE_RESULT_NO;
+      }
+
       if (evaluation == COVERAGE_RESULT_YES) {
         return true;
       } else if (evaluation == COVERAGE_RESULT_NO) {

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecPerformancePointCoverageProvider.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecPerformancePointCoverageProvider.java
@@ -88,9 +88,8 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
    */
   public static @PerformancePointCoverageResult int areResolutionAndFrameRateCovered(
       VideoCapabilities videoCapabilities, int width, int height, double frameRate) {
-    // MIREGO added !doNotIgnorePerformancePointsForResolutionAndFrameRate condition
     if (Util.SDK_INT < 29
-        || (!Util.doNotIgnorePerformancePointsForResolutionAndFrameRate && shouldIgnorePerformancePoints != null && shouldIgnorePerformancePoints)) {
+        || (shouldIgnorePerformancePoints != null && shouldIgnorePerformancePoints)) {
       return COVERAGE_RESULT_NO_PERFORMANCE_POINTS_UNSUPPORTED;
     }
 
@@ -118,8 +117,7 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
       int performancePointCoverageResult =
           evaluatePerformancePointCoverage(performancePointList, targetPerformancePoint);
 
-      if (!Util.doNotIgnorePerformancePointsForResolutionAndFrameRate // MIREGO added to select devices on which we do not want to ignore the performance points
-          && performancePointCoverageResult == COVERAGE_RESULT_NO
+      if (performancePointCoverageResult == COVERAGE_RESULT_NO
           && shouldIgnorePerformancePoints == null) {
         // See https://github.com/google/ExoPlayer/issues/10898,
         // https://github.com/androidx/media/issues/693,

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecPerformancePointCoverageProvider.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecPerformancePointCoverageProvider.java
@@ -88,8 +88,9 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
    */
   public static @PerformancePointCoverageResult int areResolutionAndFrameRateCovered(
       VideoCapabilities videoCapabilities, int width, int height, double frameRate) {
+    // MIREGO added !doNotIgnorePerformancePointsForResolutionAndFrameRate condition
     if (Util.SDK_INT < 29
-        || (shouldIgnorePerformancePoints != null && shouldIgnorePerformancePoints)) {
+        || (!Util.doNotIgnorePerformancePointsForResolutionAndFrameRate && shouldIgnorePerformancePoints != null && shouldIgnorePerformancePoints)) {
       return COVERAGE_RESULT_NO_PERFORMANCE_POINTS_UNSUPPORTED;
     }
 
@@ -117,7 +118,8 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
       int performancePointCoverageResult =
           evaluatePerformancePointCoverage(performancePointList, targetPerformancePoint);
 
-      if (performancePointCoverageResult == COVERAGE_RESULT_NO
+      if (!Util.doNotIgnorePerformancePointsForResolutionAndFrameRate // MIREGO added to select devices on which we do not want to ignore the performance points
+          && performancePointCoverageResult == COVERAGE_RESULT_NO
           && shouldIgnorePerformancePoints == null) {
         // See https://github.com/google/ExoPlayer/issues/10898,
         // https://github.com/androidx/media/issues/693,
@@ -140,10 +142,6 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
         return false;
       }
 
-      // MIREGO added to select devices on which we do not want to ignore the performance points
-      if (Util.doNotIgnorePerformancePointsForResolutionAndFrameRate) {
-        return false;
-      }
       try {
         Format formatH264 = new Format.Builder().setSampleMimeType(MimeTypes.VIDEO_H264).build();
         // Null check required to pass RequiresNonNull annotation on getDecoderInfosSoftMatch.


### PR DESCRIPTION
In #19 I added a way to ignore a bug fix recently added by google that is having a negative impact on playback performance on some devices.
I realized just after that since there's lazy evaluation on the result of the added check, for the change to apply the app would have needed to be restarted. It's not a huge deal, since the app is restarted from time to time, and we don't plan on changing the device list that often. But I still found that annoying.
This PR improves on #19 by making sure we can change the value of the added boolean, and it will have an impact on the next codec change, not the next application execution. To do so, we keep the lazy eval system as it is, but we override the result higher in the stack.