### PR TITLE
Add a way to not ignore performance points for resolution and frame rate (3rd try)

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecInfo.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecInfo.java
@@ -538,12 +538,6 @@ public final class MediaCodecInfo {
       int evaluation =
           MediaCodecPerformancePointCoverageProvider.areResolutionAndFrameRateCovered(
               videoCapabilities, width, height, frameRate);
-
-      // MIREGO added support for doNotIgnorePerformancePointsForResolutionAndFrameRate
-      if (evaluation == COVERAGE_RESULT_NO_PERFORMANCE_POINTS_UNSUPPORTED && Util.doNotIgnorePerformancePointsForResolutionAndFrameRate) {
-        evaluation = COVERAGE_RESULT_NO;
-      }
-
       if (evaluation == COVERAGE_RESULT_YES) {
         return true;
       } else if (evaluation == COVERAGE_RESULT_NO) {

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecPerformancePointCoverageProvider.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecPerformancePointCoverageProvider.java
@@ -88,6 +88,18 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
    */
   public static @PerformancePointCoverageResult int areResolutionAndFrameRateCovered(
       VideoCapabilities videoCapabilities, int width, int height, double frameRate) {
+
+    // MIREGO: added support for doNotIgnorePerformancePointsForResolutionAndFrameRate
+    // some devices now drop lots of frames due to COVERAGE_RESULT_NO_PERFORMANCE_POINTS_UNSUPPORTED
+    // we want to be able to disable it for some device models
+    if (Util.doNotIgnorePerformancePointsForResolutionAndFrameRate && Util.SDK_INT >= 29) {
+      int evaluation = Api29.areResolutionAndFrameRateCovered(videoCapabilities, width, height, frameRate);
+      if (evaluation == COVERAGE_RESULT_NO_PERFORMANCE_POINTS_UNSUPPORTED) {
+        return COVERAGE_RESULT_NO;
+      }
+      return evaluation;
+    }
+
     if (Util.SDK_INT < 29
         || (shouldIgnorePerformancePoints != null && shouldIgnorePerformancePoints)) {
       return COVERAGE_RESULT_NO_PERFORMANCE_POINTS_UNSUPPORTED;


### PR DESCRIPTION
In https://github.com/androidx/media/commit/3521ccda9be020419e966308f985fa899b083a45, a fallback was added when there is no coverage for 720p 60 FPS. That introduced performance issues on several device models that are now dropping 15-40 frames / sec in Live playback (depending on the model). That's because they used to stay at a lower resolution/framerate, and are now trying to playback 720P 60 FPS, but they struggle to do so.

This PR will allow us to disable the fallback on the identified device models. So they will revert to using the lower fps track.

Previous attempts #19 and #20 had an issue with lower resolutions. They were handling the formats that we didn't want to be supported correctly, but they were also discarding lower resolutions/frame rates.
This one has been tested on a device similar to the ones with the issue, and is confirmed to work properly.