### PR TITLE
Change custom error code handling

### DIFF
--- a/libraries/common/src/main/java/androidx/media3/common/PlaybackException.java
+++ b/libraries/common/src/main/java/androidx/media3/common/PlaybackException.java
@@ -293,7 +293,7 @@ public class PlaybackException extends Exception implements Bundleable {
    * Player implementations that want to surface custom errors can use error codes greater than this
    * value, so as to avoid collision with other error codes defined in this class.
    */
-  public static final int CUSTOM_ERROR_CODE_BASE = 1000000;
+  public static final int CUSTOM_ERROR_CODE_BASE = 9000;  // MIREGO: changed from 1000000, it looked weird
 
   /** Returns the name of a given {@code errorCode}. */
   public static String getErrorCodeName(@ErrorCode int errorCode) {
@@ -388,7 +388,7 @@ public class PlaybackException extends Exception implements Bundleable {
 
       default:
         if (errorCode >= CUSTOM_ERROR_CODE_BASE) {
-          return "custom error code";
+          return "Error code " + errorCode;
         } else {
           return "invalid error code";
         }


### PR DESCRIPTION
As part of an issue investigation, I used a custom error code defined in our app.
Testing the error screen, I found it didn't look good to expose "custom error code" on an error screen, so I changed it to display "Error code" and the actual code.
But then I found it also looked weird to display: "Error code 1000000".
So I changed the custom code start to 9000.