### PR TITLE
Add debug info to help debugging a pipeline stall issue  (2)

### DIFF
--- a/libraries/common/src/main/java/androidx/media3/common/util/Util.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/Util.java
@@ -189,7 +189,8 @@ public final class Util {
   public static int audioLastFeedInputBufferStep = 0;
   public static int videoLastDrainOutputBufferStep = 0;
   public static int audioLastDrainOutputBufferStep = 0;
-  public static int currentAccumulatedVideoQueuedFrames = 0;
+  public static int currentQueuedInputBuffers = 0;
+  public static int currentProcessedOutputBuffers = 0;
 
   /** An empty long array. */
   @UnstableApi public static final long[] EMPTY_LONG_ARRAY = new long[0];

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -734,7 +734,8 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
     hasNotifiedAvDesyncError = false;
     hasNotifiedAvDesyncSkippedFramesError = false;
     queuedFrames = 0;
-    Util.currentAccumulatedVideoQueuedFrames = 0;
+    Util.currentQueuedInputBuffers = 0;
+    Util.currentProcessedOutputBuffers = 0;
 
     videoFrameReleaseControl.onStarted();
   }
@@ -1227,7 +1228,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
 
     // MIREGO: added
     queuedFrames++;
-    Util.currentAccumulatedVideoQueuedFrames++;
+    Util.currentQueuedInputBuffers++;
     if (queuedFrames >= NOTIFY_QUEUED_FRAMES_THRESHOLD) {
       maybeNotifyQueuedFrames();
     }
@@ -1613,6 +1614,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
   @CallSuper
   @Override
   protected void onProcessedOutputBuffer(long presentationTimeUs) {
+    Util.currentProcessedOutputBuffers++;
     super.onProcessedOutputBuffer(presentationTimeUs);
     if (!tunneling) {
       buffersInCodecCount--;


### PR DESCRIPTION
In #23, we've added some debug info to help debug an issue where the rendering pipeline seems to be stalled.

This PR adds the processed buffer count to the debug info and also renamed the queued input buffer count to make it clearer.