### PR TITLE
Adds an error log when a potential video codec stall is detected

### DIFF
--- a/libraries/common/src/main/java/androidx/media3/common/PlaybackException.java
+++ b/libraries/common/src/main/java/androidx/media3/common/PlaybackException.java
@@ -244,6 +244,9 @@ public class PlaybackException extends Exception implements Bundleable {
   /** MIREGO: Caused by a network error trying to get time from the NTP server */
   public static final int ERROR_CODE_NTP = 5905;
 
+  /** MIREGO: Caused by the video codec being stalled (issue under investigation) */
+  public static final int ERROR_CODE_VIDEO_CODEC_STALLED = 5906;
+
   // DRM errors (6xxx).
 
   /** Caused by an unspecified error related to DRM protection. */
@@ -385,6 +388,8 @@ public class PlaybackException extends Exception implements Bundleable {
         return "ERROR_CODE_AUDIO_WAITING_FOR_HEAD_POSITION_RESET";
       case ERROR_CODE_NTP:
         return "ERROR_CODE_NTP";
+      case ERROR_CODE_VIDEO_CODEC_STALLED:
+        return "ERROR_CODE_VIDEO_CODEC_STALLED";
 
       default:
         if (errorCode >= CUSTOM_ERROR_CODE_BASE) {

--- a/libraries/common/src/main/java/androidx/media3/common/util/Util.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/Util.java
@@ -184,13 +184,14 @@ public final class Util {
   public static boolean useDifferentAudioSessionIdForTunneling = false; // MIREGO ADDED
   public static int ntpTimeoutMs = 5000; // MIREGO ADDED
 
-  // TEMP DEBUG STUFF
+  // TEMP DEBUG STUFF (to investigate an infinite buffering issue caused by what seems to be a video codec stall)
   public static int videoLastFeedInputBufferStep = 0;
   public static int audioLastFeedInputBufferStep = 0;
   public static int videoLastDrainOutputBufferStep = 0;
   public static int audioLastDrainOutputBufferStep = 0;
   public static int currentQueuedInputBuffers = 0;
   public static int currentProcessedOutputBuffers = 0;
+  public static long waitingForDecodedVideoBufferTimeMs = 0;
 
   /** An empty long array. */
   @UnstableApi public static final long[] EMPTY_LONG_ARRAY = new long[0];

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -734,8 +734,6 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
     hasNotifiedAvDesyncError = false;
     hasNotifiedAvDesyncSkippedFramesError = false;
     queuedFrames = 0;
-    Util.currentQueuedInputBuffers = 0;
-    Util.currentProcessedOutputBuffers = 0;
 
     videoFrameReleaseControl.onStarted();
   }
@@ -777,6 +775,9 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
       if (placeholderSurface != null) {
         releasePlaceholderSurface();
       }
+      Util.currentQueuedInputBuffers = 0;
+      Util.currentProcessedOutputBuffers = 0;
+      Util.waitingForDecodedVideoBufferTimeMs = 0;
     }
   }
 


### PR DESCRIPTION
We have a production issue where we get infinite fast state flips between buffering and playing after a while.
So far, investigations have allowed us to understand that the issue seems that video frames do not get out of the codec. So after approximately 3 mins, the playhead gets to the end of the video buffer, so the player switches immediately to buffering. But at the same, the buffer is full (it's not being consumed anymore) so the buffering system flips it back to playing immediately. And that cycle is then repeated.

This PR adds a way to detect the codec stall situation, and send an error through the logger. The app will then be able to handle the error properly (potentially by restarting the playback automatically).

To do so, we just check if we've been waiting for a decoded buffer for a certain time without getting any.