### PR TITLE
Fix potential video codec stall in tunneling

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -1642,7 +1642,6 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
   @Override
   protected void onProcessedOutputBuffer(long presentationTimeUs) {
     Util.currentProcessedOutputBuffers++;
-    Util.waitingForDecodedVideoBufferTimeMs = 0; // we have to also reset the timer here, because in tunneling we don't handle the decoded buffers
     super.onProcessedOutputBuffer(presentationTimeUs);
     if (!tunneling) {
       buffersInCodecCount--;

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -1616,6 +1616,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
   @Override
   protected void onProcessedOutputBuffer(long presentationTimeUs) {
     Util.currentProcessedOutputBuffers++;
+    Util.waitingForDecodedVideoBufferTimeMs = 0; // we have to also reset the timer here, because in tunneling we don't handle the decoded buffers
     super.onProcessedOutputBuffer(presentationTimeUs);
     if (!tunneling) {
       buffersInCodecCount--;

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -1616,9 +1616,6 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
     if (hasDequeuedBuffer) {
         Util.waitingForDecodedVideoBufferTimeMs = 0; // we got a decoded buffer, reset the wait time
     } else {
-      System.out.println("SMO currentQueuedInputBuffers " + Util.currentQueuedInputBuffers
-          + " currentProcessedOutputBuffers "
-          + Util.currentProcessedOutputBuffers);
       if (Util.currentProcessedOutputBuffers < Util.currentQueuedInputBuffers) {
         // waiting for a decoded buffer to be available from the codec
         long currentTimeMs = System.currentTimeMillis();


### PR DESCRIPTION
In #26 I added an error when we detect a potential stall of the video renderer (probably caused by the codec).
It wasn't working properly in tunneling, because we never handle the decoded buffer (that's pretty much what tunneling does). It was triggering 100% because of that.
This PR disables the detection in tunneling. And also cleans up how it was done.