### PR TITLE
Add support for multiple offline DRM keys

### DIFF
--- a/libraries/common/src/main/java/androidx/media3/common/DrmInitData.java
+++ b/libraries/common/src/main/java/androidx/media3/common/DrmInitData.java
@@ -370,6 +370,18 @@ public final class DrmInitData implements Comparator<SchemeData>, Parcelable {
       return hashCode;
     }
 
+    // MIREGO: added toString
+    @Override
+    public String toString() {
+      return "SchemeData{" +
+          "hashCode=" + hashCode +
+          ", uuid=" + uuid +
+          ", licenseServerUrl='" + licenseServerUrl + '\'' +
+          ", mimeType='" + mimeType + '\'' +
+          ", data=" + Arrays.toString(data) +
+          '}';
+    }
+
     // Parcelable implementation.
 
     @Override

--- a/libraries/common/src/main/java/androidx/media3/common/PlaybackException.java
+++ b/libraries/common/src/main/java/androidx/media3/common/PlaybackException.java
@@ -310,6 +310,9 @@ public class PlaybackException extends Exception {
   /** MIREGO: Caused by the video codec being stalled (issue under investigation) */
   public static final int ERROR_CODE_VIDEO_CODEC_STALLED = 5906;
 
+  /** MIREGO: Caused by a Drm offline key hashcode not found in the hash codes array */
+  public static final int ERROR_CODE_OFFLINE_DRM_HASH_CODE_NOT_FOUND = 5907;
+
   // DRM errors (6xxx).
 
   /** Caused by an unspecified error related to DRM protection. */
@@ -483,6 +486,8 @@ public class PlaybackException extends Exception {
         return "ERROR_CODE_NTP";
       case ERROR_CODE_VIDEO_CODEC_STALLED:
         return "ERROR_CODE_VIDEO_CODEC_STALLED";
+      case ERROR_CODE_OFFLINE_DRM_HASH_CODE_NOT_FOUND:
+        return "ERROR_CODE_OFFLINE_DRM_HASH_CODE_NOT_FOUND";
 
       default:
         if (errorCode >= CUSTOM_ERROR_CODE_BASE) {

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/DefaultDrmSession.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/DefaultDrmSession.java
@@ -123,6 +123,9 @@ import org.checkerframework.checker.nullness.qual.RequiresNonNull;
   /** The DRM scheme datas, or null if this session uses offline keys. */
   @Nullable public final List<SchemeData> schemeDatas;
 
+  // MIREGO: added to be able to reuse offline sessions with compatible data without messing with the field schemeDatas, that is used to determine if it's an offline key when getting the key request
+  @Nullable public final List<SchemeData> schemeDatasEvenOffline;
+
   private final ExoMediaDrm mediaDrm;
   private final ProvisioningManager provisioningManager;
   private final ReferenceCountListener referenceCountListener;
@@ -202,6 +205,9 @@ import org.checkerframework.checker.nullness.qual.RequiresNonNull;
     } else {
       this.schemeDatas = Collections.unmodifiableList(Assertions.checkNotNull(schemeDatas));
     }
+    // MIREGO: added.
+    this.schemeDatasEvenOffline = Collections.unmodifiableList(Assertions.checkNotNull(schemeDatas));
+
     this.keyRequestParameters = keyRequestParameters;
     this.callback = callback;
     this.eventDispatchers = new CopyOnWriteMultiset<>();

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/DefaultDrmSessionManager.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/DefaultDrmSessionManager.java
@@ -746,6 +746,9 @@ public class DefaultDrmSessionManager implements DrmSessionManager {
       if (index >= 0) {
         offlineLicenseKeySetId = offlineLicenseKeySetIdList.get(index);
       } else {  // oops, we haven't found the drmInitData hash. We might as well fallback to the first key.
+        Log.e(TAG,
+            new PlaybackException("Offline Drm hash code not found. Trying first available key", new RuntimeException(),
+                PlaybackException.ERROR_CODE_OFFLINE_DRM_HASH_CODE_NOT_FOUND));
         offlineLicenseKeySetId = offlineLicenseKeySetIdList.get(0);
       }
     }


### PR DESCRIPTION
We need to support multiple DRM keys for different time periods on offline playbacks. This wasn't supported by ExoPlayer.

This PR adds support for multiple keys.
- Added a new setMode function in DefaultDrmSessionManager to be able to pass the needed data (lists of drmKeys and list of hash codes to find the right key for a given format)
- Replaced the single keySetId in DefaultDrmSessionManager by the above 2 lists
- When we acquire a session with a new format, use the hash codes list to find the index of the right key to use, instead of using the single offline key.

Notes:
- I had to add a field in DefaultDrmSession to be able to reuse the session. The existing schemeDatas is used in multiple ways, so changing it to keep the scheme datas even for offline playback would have required more changes (we try to limit the scope of changes to facilitate merges)
- I initially also made the similar changes in MediaItem (which is given the offline key). But after investigation, turns out this code path is useless for us, we override or handle ourselves all the related object creation. So for the same reason as the previous point, I decided to revert those changes.