### PR TITLE
Fix CC getting stuck and eventually stalling the pipeline

### DIFF
--- a/libraries/extractor/src/main/java/androidx/media3/extractor/text/cea/CeaDecoder.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/text/cea/CeaDecoder.java
@@ -85,7 +85,7 @@ import java.util.PriorityQueue;
   public void queueInputBuffer(SubtitleInputBuffer inputBuffer) throws SubtitleDecoderException {
     Assertions.checkArgument(inputBuffer == dequeuedInputBuffer);
     CeaInputBuffer ceaInputBuffer = (CeaInputBuffer) inputBuffer;
-    // MIREGO added isEndOfStream condition to avoid the buffer signaling the end of stream to be skipped
+    // MIREGO: added !isEndOfStream condition to avoid the buffer signaling the end of stream to be skipped
     if (outputStartTimeUs != C.TIME_UNSET && ceaInputBuffer.timeUs < outputStartTimeUs && !ceaInputBuffer.isEndOfStream()) {
       // We can start decoding anywhere in CEA formats, so discarding on the input side is fine.
       releaseInputBuffer(ceaInputBuffer);

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/text/cea/CeaDecoder.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/text/cea/CeaDecoder.java
@@ -85,7 +85,8 @@ import java.util.PriorityQueue;
   public void queueInputBuffer(SubtitleInputBuffer inputBuffer) throws SubtitleDecoderException {
     Assertions.checkArgument(inputBuffer == dequeuedInputBuffer);
     CeaInputBuffer ceaInputBuffer = (CeaInputBuffer) inputBuffer;
-    if (outputStartTimeUs != C.TIME_UNSET && ceaInputBuffer.timeUs < outputStartTimeUs) {
+    // MIREGO added isEndOfStream condition to avoid the buffer signaling the end of stream to be skipped
+    if (outputStartTimeUs != C.TIME_UNSET && ceaInputBuffer.timeUs < outputStartTimeUs && !ceaInputBuffer.isEndOfStream()) {
       // We can start decoding anywhere in CEA formats, so discarding on the input side is fine.
       releaseInputBuffer(ceaInputBuffer);
     } else {


### PR DESCRIPTION
In 1.4.1 a check was added when queuing an input buffer in CeaDecoder to avoid queuing an obsolete buffer (time in the past). That created a major issue. When switching the stream to a new period, a buffer is queued to signal the end of the stream, and its time is not initialized. It can be a value previously read from the source but not queued yet, or TIME_END_OF_SOURCE in our case. It didn't matter before, because anyway, later in the pipe, if it's an end of stream buffer, its time is irrelevant. But the added check makes it skip the buffer queuing. And that stalls the CC pipeline, which in turn stall the entirety of the rendering at the following period change.

This PR fixes it, by making sure we do not skip queueing the buffer signalling the end of stream.