### PR TITLE
Fix CC samples message in queue polluting TextRenderer source stream samples post seek

### DIFF
--- a/libraries/container/src/main/java/androidx/media3/container/ReorderingSeiMessageQueue.java
+++ b/libraries/container/src/main/java/androidx/media3/container/ReorderingSeiMessageQueue.java
@@ -184,6 +184,25 @@ public final class ReorderingSeiMessageQueue {
     }
   }
 
+  /**
+   * MIREGO: (added) Empties the queue, discarding all messages without consuming them
+   */
+  public void clear() {
+    while (pendingSeiMessages.size() > 0) {
+      SampleSeiMessages sampleSeiMessages = castNonNull(pendingSeiMessages.poll());
+      for (int i = 0; i < sampleSeiMessages.nalBuffers.size(); i++) {
+        unusedParsableByteArrays.push(sampleSeiMessages.nalBuffers.get(i));
+      }
+      sampleSeiMessages.nalBuffers.clear();
+      if (lastQueuedMessage != null
+          && lastQueuedMessage.presentationTimeUs == sampleSeiMessages.presentationTimeUs) {
+        lastQueuedMessage = null;
+      }
+      unusedSampleSeiMessages.push(sampleSeiMessages);
+    }
+  }
+
+
   /** Holds the presentation timestamp of a sample and the data from associated SEI messages. */
   private static final class SampleSeiMessages implements Comparable<SampleSeiMessages> {
 

--- a/libraries/container/src/main/java/androidx/media3/container/ReorderingSeiMessageQueue.java
+++ b/libraries/container/src/main/java/androidx/media3/container/ReorderingSeiMessageQueue.java
@@ -185,7 +185,7 @@ public final class ReorderingSeiMessageQueue {
   }
 
   /**
-   * MIREGO: (added) Empties the queue, discarding all messages without consuming them
+   * MIREGO: (added) Clears the queue, discarding all messages without consuming them
    */
   public void clear() {
     while (pendingSeiMessages.size() > 0) {

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/FragmentedMp4Extractor.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/FragmentedMp4Extractor.java
@@ -475,7 +475,7 @@ public class FragmentedMp4Extractor implements Extractor {
     }
     pendingMetadataSampleInfos.clear();
     pendingMetadataSampleBytes = 0;
-    reorderingSeiMessageQueue.flush();
+    reorderingSeiMessageQueue.clear();  //MIREGO: clear the message queue instead of flush, to avoid a race where a pre-seek CC sample gets in the text renderer source stream post-seek
     pendingSeekTimeUs = timeUs;
     containerAtoms.clear();
     enterReadingAtomHeaderState();


### PR DESCRIPTION
When seeking (resetting the position), the renderers streams are "reset". When doing that, the MP4 extractor flushes its pending messages queue.
That flush happens in a different thread than the main ExoPlayer thread. It can happen that a pending CC sample in the queue is processed after the TextRenderer stream has been flushed. When that happens, we end up with a pre-seek CC sample at the head of the post-seek TextRenderer samples FIFO.
When seeking in the past, that sample is in the future, compared to the current stream position, and to the following samples. That future sample effectively blocks any CC to be displayed until the playback position reaches the sample time. And then, all the following samples are displayed very fast (1 sample per update / ms), until we reach the playback time in the previously blocked queue.

The PR fixes the issue by replacing the message queue flush that was done when seeking in the MP4 Extractor by a clear. We empty the queue and recycle its containers, but we do not consume the messages.