### PR TITLE
Workaround platform issue causing severe AV desync when seeking

### DIFF
--- a/libraries/common/src/main/java/androidx/media3/common/util/Util.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/Util.java
@@ -189,6 +189,8 @@ public final class Util {
   public static boolean shouldIgnoreCodecFpsLimitForResolution = false; // MIREGO ADDED
   public static boolean doNotIgnorePerformancePointsForResolutionAndFrameRate = false; // MIREGO ADDED
 
+  public static boolean pendingAudioTrackReleaseShouldBlockNewTrackCreation = false; // MIREGO ADDED
+
   // TEMP DEBUG STUFF (to investigate an infinite buffering issue caused by what seems to be a video codec stall)
   public static int videoLastFeedInputBufferStep = 0;
   public static int audioLastFeedInputBufferStep = 0;

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
@@ -2468,6 +2468,11 @@ public final class DefaultAudioSink implements AudioSink {
     }
 
     public boolean shouldWaitBeforeRetry() {
+      if (Util.pendingAudioTrackReleaseShouldBlockNewTrackCreation && hasPendingAudioTrackReleases()) {
+        // Wait until other tracks are released to workaround a platform issue
+        return true;
+      }
+
       if (pendingException == null) {
         // No pending exception.
         return false;

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
@@ -2468,6 +2468,7 @@ public final class DefaultAudioSink implements AudioSink {
     }
 
     public boolean shouldWaitBeforeRetry() {
+      // MIREGO added to workaround a platform issue
       if (Util.pendingAudioTrackReleaseShouldBlockNewTrackCreation && hasPendingAudioTrackReleases()) {
         // Wait until other tracks are released to workaround a platform issue
         return true;


### PR DESCRIPTION
We have an issue on a device on ATV14, where seeking was frequently causing severe AV desync. This was correlated with audioFlinger error messages.
Current conclusion is that releasing an audio track after the new one has been created is causing the issue in the platform code. 
before Exo 1.5.1, the creation of a new track was always blocked until the pending release had been completed.
This PR adds a switch that will block the creation of the new one until the previous one has been released, as it was doing before.
This should fix the issue temporarily, until the platform provider can find and fix the root cause.