### PR TITLE
Fix tunneled dropped frames detection

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -408,7 +408,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
   private long positionUsPrev = 0;
   private long bufferPresentationTimeUsPrev = 0;
   private long frameDurationUs = 0;
-  private long firstFrameRenderedSystemMs = 0;
+  private long firstTunneledFrameRenderedSystemMs = 0;
   private long lastRenderedTunneledBufferPresentationTimeUs = 0;
   private int queuedFrames = 0;
   private long queuedFrameAccumulationStartTimeMs;
@@ -1027,6 +1027,10 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
     }
     maybeSetupTunnelingForFirstFrame();
     consecutiveDroppedFrameCount = 0;
+
+    // MIREGO added following block for tunneled rendering dropped frames detection
+    firstTunneledFrameRenderedSystemMs = 0;
+    lastRenderedTunneledBufferPresentationTimeUs = 0;
   }
 
   @Override
@@ -1068,8 +1072,6 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
     }
 
     // MIREGO added following block
-    firstFrameRenderedSystemMs = 0;
-    lastRenderedTunneledBufferPresentationTimeUs = 0;
     hasNotifiedAvDesyncError = false;
     hasNotifiedAvDesyncSkippedFramesError = false;
     queuedFrames = 0;
@@ -1962,8 +1964,8 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
    */
   private void detectTunnelingDroppedFrames(long presentationTimeUs) {
     long systemMs = System.currentTimeMillis();
-    if (firstFrameRenderedSystemMs == 0) {
-      firstFrameRenderedSystemMs = systemMs;
+    if (firstTunneledFrameRenderedSystemMs == 0) {
+      firstTunneledFrameRenderedSystemMs = systemMs;
     }
 
     if (presentationTimeUs < lastRenderedTunneledBufferPresentationTimeUs) {
@@ -1976,7 +1978,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
     // so if we rendered a frame more than (1 / framerate) later than the previous one, we dropped frame(s)
     if ( (lastRenderedTunneledBufferPresentationTimeUs > 0)
         && (frameDurationUs > 0)
-        && (systemMs - firstFrameRenderedSystemMs > IGNORE_PRIMING_DROPPED_FRAMES_MS)
+        && (systemMs - firstTunneledFrameRenderedSystemMs > IGNORE_PRIMING_DROPPED_FRAMES_MS)
     ) {
       // round to the nearest since timestamps don't have infinite precision (otherwise 0.99999999 of a frame duration would compute as 0 frame)
       int framesElapsed = (int) (((presentationTimeUs - lastRenderedTunneledBufferPresentationTimeUs) + (frameDurationUs / 2)) / frameDurationUs);

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -408,6 +408,8 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
   private long positionUsPrev = 0;
   private long bufferPresentationTimeUsPrev = 0;
   private long frameDurationUs = 0;
+  private boolean tunneledDroppedFramesDetectionEnabled = false;
+  private long maxQueuedFramePresentationTime = -1;
   private long firstTunneledFrameRenderedSystemMs = 0;
   private long lastRenderedTunneledBufferPresentationTimeUs = 0;
   private int queuedFrames = 0;
@@ -997,6 +999,10 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
 
   @Override
   protected void onPositionReset(long positionUs, boolean joining) throws ExoPlaybackException {
+    // MIREGO disable tunneled dropped frames detection until we get onStarted()
+    tunneledDroppedFramesDetectionEnabled = false;
+    maxQueuedFramePresentationTime = -1;
+
     if (videoSink != null) {
       if (!joining) {
         // Flush the video sink first to ensure it stops reading textures that will be owned by
@@ -1027,10 +1033,6 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
     }
     maybeSetupTunnelingForFirstFrame();
     consecutiveDroppedFrameCount = 0;
-
-    // MIREGO added following block for tunneled rendering dropped frames detection
-    firstTunneledFrameRenderedSystemMs = 0;
-    lastRenderedTunneledBufferPresentationTimeUs = 0;
   }
 
   @Override
@@ -1060,6 +1062,12 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
   @Override
   protected void onStarted() {
     super.onStarted();
+
+    // MIREGO: enable tunneled dropped frames detection
+    firstTunneledFrameRenderedSystemMs = 0;
+    lastRenderedTunneledBufferPresentationTimeUs = 0;
+    tunneledDroppedFramesDetectionEnabled = true;
+
     droppedFrames = 0;
     long elapsedRealtimeMs = getClock().elapsedRealtime();
     droppedFrameAccumulationStartTimeMs = elapsedRealtimeMs;
@@ -1530,11 +1538,16 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
   @Override
   protected void onQueueInputBuffer(DecoderInputBuffer buffer) throws ExoPlaybackException {
 
-    // MIREGO: added
+    // MIREGO: added block for metrics
     queuedFrames++;
     Util.currentQueuedInputBuffers++;
     if (queuedFrames >= NOTIFY_QUEUED_FRAMES_THRESHOLD) {
       maybeNotifyQueuedFrames();
+    }
+
+    // MIREGO: added block to detect dropped frames in tunneled rendering
+    if (buffer.timeUs > maxQueuedFramePresentationTime) {
+      maxQueuedFramePresentationTime = buffer.timeUs;
     }
 
     if (av1SampleDependencyParser != null
@@ -1964,13 +1977,17 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
    */
   private void detectTunnelingDroppedFrames(long presentationTimeUs) {
     long systemMs = System.currentTimeMillis();
+    if (!tunneledDroppedFramesDetectionEnabled || (maxQueuedFramePresentationTime <= 0)) {
+      return;
+    }
+
     if (firstTunneledFrameRenderedSystemMs == 0) {
       firstTunneledFrameRenderedSystemMs = systemMs;
     }
 
-    if (presentationTimeUs < lastRenderedTunneledBufferPresentationTimeUs) {
-      // workaround an issue on a platform where the codec sends us a faulty presentation time
-      // in that case, fake that we got what we expected.
+    // workaround an issue on a platform where the codec sends us a transformed presentation time (could be a systemNanos presentation time)
+    // in that case, fake that we got what we expected.
+    if ((presentationTimeUs < lastRenderedTunneledBufferPresentationTimeUs) || (presentationTimeUs > maxQueuedFramePresentationTime)) {
       presentationTimeUs = lastRenderedTunneledBufferPresentationTimeUs + frameDurationUs;
     }
 


### PR DESCRIPTION
Dropped frames detection in tunneled playback isn't supported in the vanilla version of ExoPlayer.
I implemented it a while ago. It uses a callback on the rendered frames to calculate how many frames were skipped since the last callback, using the time delta between the new presentation time and the previous one.

It was generally working ok, but we found issues on live content. The presentation frame of reference can change when we switch channel. And there was a potential race, where we would receive the callback for the previous stream as we had reset fields to handle the new stream.

There was also an issue where sometimes, on at least one platform, we would receive presentation times completely out of range. The doc states that the platform can send us transformed presentation times, so it is legit. But we have to handle it. It was kind of handled before, but wasn't handling when the presentation time would be higher than our range. I had only saw that it was lower before, but now we support DLAR, and the times reference frame can be very different.

This PR fixes both.
Make sure we disable the dropped frames detection when we're switching streams.
Also detect when the presentation time is higher than the highest time we queued in the input buffer.