### PR TITLE
Add a log to investigate ERROR_CODE_BEHIND_LIVE_WINDOW

### DIFF
--- a/libraries/exoplayer_dash/src/main/java/androidx/media3/exoplayer/dash/DefaultDashChunkSource.java
+++ b/libraries/exoplayer_dash/src/main/java/androidx/media3/exoplayer/dash/DefaultDashChunkSource.java
@@ -74,6 +74,8 @@ import org.checkerframework.checker.nullness.qual.RequiresNonNull;
 @UnstableApi
 public class DefaultDashChunkSource implements DashChunkSource {
 
+  private static final String TAG = "DefaultDashChunkSource";
+
   /** {@link DashChunkSource.Factory} for {@link DefaultDashChunkSource} instances. */
   public static final class Factory implements DashChunkSource.Factory {
 
@@ -1062,6 +1064,7 @@ public class DefaultDashChunkSource implements DashChunkSource {
         // The new index continues where the old one ended, with no overlap.
         newSegmentNumShift += oldIndexLastSegmentNum + 1 - newIndexFirstSegmentNum;
       } else if (oldIndexEndTimeUs < newIndexStartTimeUs) {
+        Log.e(TAG, "Manifest error oldIndexEndTimeUs < newIndexStartTimeUs oldIndexStartTimeUs=" + oldIndexStartTimeUs + " oldIndexEndTimeUs=" + oldIndexEndTimeUs + " newIndexStartTimeUs=" + newIndexStartTimeUs);
         // There's a gap between the old index and the new one which means we've slipped behind the
         // live window and can't proceed.
         throw new BehindLiveWindowException();


### PR DESCRIPTION
We noticed ERROR_CODE_BEHIND_LIVE_WINDOW errors recently. Seems related to some manifest manipulations. We'd like to help BE understand what's going on. This PR adds a log before throwing the error, to give a hint as to what's happening.