### PR TITLE
Add a way to set PARAMETER_KEY_TUNNEL_PEEK

### DIFF
--- a/libraries/common/src/main/java/androidx/media3/common/util/Util.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/Util.java
@@ -195,6 +195,8 @@ public final class Util {
 
   public static boolean pendingAudioTrackReleaseShouldBlockNewTrackCreation = false; // MIREGO ADDED
 
+  public static boolean shouldUseTunnelPeek = false; // MIREGO ADDED
+
   // TEMP DEBUG STUFF (to investigate an infinite buffering issue caused by what seems to be a video codec stall)
   public static int videoLastFeedInputBufferStep = 0;
   public static int audioLastFeedInputBufferStep = 0;

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -2332,9 +2332,6 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
 
 
   private void maybeSetupTunnelingForFirstFrame() {
-    // MIREGO: added function to set PARAMETER_KEY_TUNNEL_PEEK
-    setTunnelPeek(Util.shouldUseTunnelPeek);
-
     if (!tunneling || Util.SDK_INT < 23) {
       // The first frame notification for tunneling is triggered by onQueueInputBuffer prior to API
       // level 23 and no setup is needed here.
@@ -2346,18 +2343,13 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
       return;
     }
     tunnelingOnFrameRenderedListener = new OnFrameRenderedListenerV23(codec);
-  }
 
-  // MIREGO added function to be able to set PARAMETER_KEY_TUNNEL_PEEK
-  private void setTunnelPeek(boolean useTunnelPeek) {
+    // MIREGO: modified to set PARAMETER_KEY_TUNNEL_PEEK
     if (Util.SDK_INT >= 33) {
-      @Nullable MediaCodecAdapter codec = getCodec();
-      if (codec != null) {
         Bundle codecParameters = new Bundle();
-        codecParameters.putInt(MediaCodec.PARAMETER_KEY_TUNNEL_PEEK, useTunnelPeek ? 1 : 0);
-        Log.d(TAG,  "setTunnelPeek to %d", useTunnelPeek ? 1 : 0);
+        codecParameters.putInt(MediaCodec.PARAMETER_KEY_TUNNEL_PEEK, Util.shouldUseTunnelPeek ? 1 : 0);
+        Log.d(TAG,  "setTunnelPeek to %s", Util.shouldUseTunnelPeek);
         codec.setParameters(codecParameters);
-      }
     }
   }
 

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -2344,15 +2344,15 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
     }
     tunnelingOnFrameRenderedListener = new OnFrameRenderedListenerV23(codec);
 
-    // MIREGO: modified to set PARAMETER_KEY_TUNNEL_PEEK
     if (Util.SDK_INT >= 33) {
       // This should be the default anyway according to the API contract, but some devices are known
       // to not adhere to this contract and need to get the parameter explicitly. See
       // https://github.com/androidx/media/issues/1169.
-        Bundle codecParameters = new Bundle();
-        codecParameters.putInt(MediaCodec.PARAMETER_KEY_TUNNEL_PEEK, Util.shouldUseTunnelPeek ? 1 : 0);
-        codec.setParameters(codecParameters);
-        Log.d(TAG, "setTunnelPeek to %s", Util.shouldUseTunnelPeek);
+      Bundle codecParameters = new Bundle();
+      // MIREGO: use shouldUseTunnelPeek to set PARAMETER_KEY_TUNNEL_PEEK
+      codecParameters.putInt(MediaCodec.PARAMETER_KEY_TUNNEL_PEEK, Util.shouldUseTunnelPeek ? 1 : 0);
+      codec.setParameters(codecParameters);
+      Log.d(TAG, "setTunnelPeek to %s", Util.shouldUseTunnelPeek);
     }
   }
 

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -206,8 +206,6 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
   private @C.VideoScalingMode int scalingMode;
   private @C.VideoChangeFrameRateStrategy int changeFrameRateStrategy;
 
-  private boolean isUsingTunnelPeek = false; // MIREGO added
-
   private long droppedFrameAccumulationStartTimeMs;
   private int droppedFrames;
   private int consecutiveDroppedFrameCount;
@@ -2358,7 +2356,6 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
         Bundle codecParameters = new Bundle();
         codecParameters.putInt(MediaCodec.PARAMETER_KEY_TUNNEL_PEEK, useTunnelPeek ? 1 : 0);
         Log.d(TAG,  "setTunnelPeek to %d", useTunnelPeek ? 1 : 0);
-        isUsingTunnelPeek = useTunnelPeek;
         codec.setParameters(codecParameters);
       }
     }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -2352,7 +2352,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
   private void setTunnelPeek(boolean useTunnelPeek) {
     if (Util.SDK_INT >= 33) {
       @Nullable MediaCodecAdapter codec = getCodec();
-      if (getCodec() != null) {
+      if (codec != null) {
         Bundle codecParameters = new Bundle();
         codecParameters.putInt(MediaCodec.PARAMETER_KEY_TUNNEL_PEEK, useTunnelPeek ? 1 : 0);
         Log.d(TAG,  "setTunnelPeek to %d", useTunnelPeek ? 1 : 0);

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -2346,10 +2346,13 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
 
     // MIREGO: modified to set PARAMETER_KEY_TUNNEL_PEEK
     if (Util.SDK_INT >= 33) {
+      // This should be the default anyway according to the API contract, but some devices are known
+      // to not adhere to this contract and need to get the parameter explicitly. See
+      // https://github.com/androidx/media/issues/1169.
         Bundle codecParameters = new Bundle();
         codecParameters.putInt(MediaCodec.PARAMETER_KEY_TUNNEL_PEEK, Util.shouldUseTunnelPeek ? 1 : 0);
-        Log.d(TAG,  "setTunnelPeek to %s", Util.shouldUseTunnelPeek);
         codec.setParameters(codecParameters);
+        Log.d(TAG, "setTunnelPeek to %s", Util.shouldUseTunnelPeek);
     }
   }
 

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -206,7 +206,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
   private @C.VideoScalingMode int scalingMode;
   private @C.VideoChangeFrameRateStrategy int changeFrameRateStrategy;
 
-  private boolean readyToRenderFirstFrameAfterReset;  // MIREGO added
+  private boolean isUsingTunnelPeek = false; // MIREGO added
 
   private long droppedFrameAccumulationStartTimeMs;
   private int droppedFrames;
@@ -1047,9 +1047,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
       return videoSink.isReady(rendererOtherwiseReady);
     }
     if (rendererOtherwiseReady
-        && (readyToRenderFirstFrameAfterReset  // MIREGO added
-        || getCodec() == null
-        || tunneling)) {
+        && (getCodec() == null || tunneling)) {
       // Not releasing frames.
       return true;
     }
@@ -2336,6 +2334,9 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
 
 
   private void maybeSetupTunnelingForFirstFrame() {
+    // MIREGO: added function to set PARAMETER_KEY_TUNNEL_PEEK
+    setTunnelPeek(Util.shouldUseTunnelPeek);
+
     if (!tunneling || Util.SDK_INT < 23) {
       // The first frame notification for tunneling is triggered by onQueueInputBuffer prior to API
       // level 23 and no setup is needed here.
@@ -2347,13 +2348,19 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
       return;
     }
     tunnelingOnFrameRenderedListener = new OnFrameRenderedListenerV23(codec);
+  }
+
+  // MIREGO added function to be able to set PARAMETER_KEY_TUNNEL_PEEK
+  private void setTunnelPeek(boolean useTunnelPeek) {
     if (Util.SDK_INT >= 33) {
-      // This should be the default anyway according to the API contract, but some devices are known
-      // to not adhere to this contract and need to get the parameter explicitly. See
-      // https://github.com/androidx/media/issues/1169.
-      Bundle codecParameters = new Bundle();
-      codecParameters.putInt(MediaCodec.PARAMETER_KEY_TUNNEL_PEEK, 1);
-      codec.setParameters(codecParameters);
+      @Nullable MediaCodecAdapter codec = getCodec();
+      if (getCodec() != null) {
+        Bundle codecParameters = new Bundle();
+        codecParameters.putInt(MediaCodec.PARAMETER_KEY_TUNNEL_PEEK, useTunnelPeek ? 1 : 0);
+        Log.d(TAG,  "setTunnelPeek to %d", useTunnelPeek ? 1 : 0);
+        isUsingTunnelPeek = useTunnelPeek;
+        codec.setParameters(codecParameters);
+      }
     }
   }
 

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -2343,7 +2343,6 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
       return;
     }
     tunnelingOnFrameRenderedListener = new OnFrameRenderedListenerV23(codec);
-
     if (Util.SDK_INT >= 33) {
       // This should be the default anyway according to the API contract, but some devices are known
       // to not adhere to this contract and need to get the parameter explicitly. See


### PR DESCRIPTION
We have an A/V desync issue when seeking on a specific platform. The platform provider is working on resolving the issue, and they said the solution will probably involve to disable PARAMETER_KEY_TUNNEL_PEEK in ExoPlayer.

PARAMETER_KEY_TUNNEL_PEEK is only available starting from android 13. It would be convenient to simplify our implementation of fast-forward/rewind with tunneling. But since we have to support versions before 13 anyway, it's not really useful to us. It defaults to true in ExoPlayer.

This PR adds a way for the app to enable or disable PARAMETER_KEY_TUNNEL_PEEK (disabled by default).

Also cleaned unused stuff I stumbled upon.