### PR TITLE
Workaround audio volume glitch on a specific device

### DIFF
--- a/libraries/common/src/main/java/androidx/media3/common/util/Util.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/Util.java
@@ -197,6 +197,8 @@ public final class Util {
 
   public static boolean shouldUseTunnelPeek = false; // MIREGO ADDED
 
+  public static boolean workaroundAudioVolumePlatformGlitch = false;
+
   // TEMP DEBUG STUFF (to investigate an infinite buffering issue caused by what seems to be a video codec stall)
   public static int videoLastFeedInputBufferStep = 0;
   public static int audioLastFeedInputBufferStep = 0;

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
@@ -19,6 +19,7 @@ import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.common.util.Assertions.checkState;
 import static androidx.media3.common.util.Util.constrainValue;
 import static androidx.media3.common.util.Util.msToUs;
+import static androidx.media3.common.util.Util.workaroundAudioVolumePlatformGlitch;
 import static androidx.media3.exoplayer.audio.AudioCapabilities.DEFAULT_AUDIO_CAPABILITIES;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
@@ -979,6 +980,15 @@ public final class DefaultAudioSink implements AudioSink {
           // Not yet ready for initialization of a new AudioTrack.
           return false;
         }
+
+        // MIREGO workaround volume issue on buggy platform. It's possible something stays stuck after starting another app on the device. Creating and releasing an audioTrack seems to solve it.
+        if (workaroundAudioVolumePlatformGlitch) {
+          workaroundAudioVolumePlatformGlitch = false;
+          audioTrack.release();
+          audioTrack = null;
+          return false;
+        }
+
         // MIREGO
         Log.v(Log.LOG_LEVEL_VERBOSE1, TAG, "handleBuffer pendingConfiguration reusing audio track");
       } catch (InitializationException e) {


### PR DESCRIPTION
We have an issue on a specific device (yup, again). After starting Netflix, the first playback volume is lower than it should. This resolves when starting a second playback, or when seeking in the first playback.
Experimentations (a.k.a. messing around), allowed to determine that the release of the first audio track/creation of another audio track, was the determining factor.

This PR works around the issue by immediately releasing the first created audio track. Since we haven't used it, we don't need to flush it and we can do it in sync. That makes the additional delay very small and shouldn't have a measurable impact on VST.

We will activate that "feature" only on the faulty platform.
