### PR TITLE
Fix playback time out when pendingAudioTrackReleaseShouldBlockNewTrackCreation and not using the single instance player

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioTrackAudioOutput.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioTrackAudioOutput.java
@@ -466,6 +466,8 @@ public final class AudioTrackAudioOutput implements AudioOutput {
                 } finally {
                   if (audioTrackThreadHandler.getLooper().getThread().isAlive()) {
                     audioTrackThreadHandler.post(() -> listeners.sendEvent(Listener::onReleased));
+                  } else {
+                    listeners.sendEvent(Listener::onReleased);
                   }
                   synchronized (releaseExecutorLock) {
                     pendingReleaseCount--;

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioTrackAudioOutput.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioTrackAudioOutput.java
@@ -466,7 +466,7 @@ public final class AudioTrackAudioOutput implements AudioOutput {
                 } finally {
                   if (audioTrackThreadHandler.getLooper().getThread().isAlive()) {
                     audioTrackThreadHandler.post(() -> listeners.sendEvent(Listener::onReleased));
-                  } else {
+                  } else { // MIREGO: that message should always be sent, otherwise the audio tracks count will not get decreased properly and stay > 0 indefinitely
                     listeners.sendEvent(Listener::onReleased);
                   }
                   synchronized (releaseExecutorLock) {


### PR DESCRIPTION
Playbacks would start to timeout sometimes following a normally working playback.
@alarochelle found that it was because the audio track count would not get down to zero, if the message handling thread is dead.
When the player is created and destroyed for each playback, the message handling thread can be dead before the audio track release is finished. The message is not sent, the count stays to 1, and further tracks creations are blocked. Since that field is static, a new player instance doesn't solve it, the app needs to be restarted.

Fix: when the thread is dead, send the message in sync.

Notes:
- There is still the potential race of the message handler being killed between the check and the send. We'll have to live with it. If it was my stuff, I'd wrap the "if (handler if not dead) sendMessage()" in the handler, including the sync fallback, and I'd make it properly thread safe.
- Although the problem is more serious and easier to see because of the track creation blocking, the issue is not specific to our fork. The count can stay to a positive value forever in the vanilla version as well. And when that happens, the track creation retry mechanism is broken.
- I believe the race that causes the handler thread to die before the track is destroyed is much easier to reproduce on *certain devices* that we won't name here, to protect the innocents.

