### PR TITLE
Fix audio track init issue on HD after tunneled playback

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/ExoPlayerImpl.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/ExoPlayerImpl.java
@@ -176,7 +176,8 @@ import java.util.concurrent.CopyOnWriteArraySet;
   private final WifiLockManager wifiLockManager;
   private final long detachSurfaceTimeoutMs;
   @Nullable private final SuitableOutputChecker suitableOutputChecker;
-  private final BackgroundThreadStateHandler<Integer> audioSessionIdState;
+  // MIREGO: use a distinct session for tunneling
+  private final BackgroundThreadStateHandler<Pair<Integer, Integer>> audioSessionIdState;
 
   private @RepeatMode int repeatMode;
   private boolean shuffleModeEnabled;
@@ -402,15 +403,17 @@ import java.util.concurrent.CopyOnWriteArraySet;
 
       audioSessionIdState =
           new BackgroundThreadStateHandler<>(
-              AUDIO_SESSION_ID_UNSET,
+              new Pair(AUDIO_SESSION_ID_UNSET, AUDIO_SESSION_ID_UNSET), // MIREGO: use a distinct session for tunneling
               playbackLooper,
               applicationLooper,
               clock,
               /* onStateChanged= */ this::onAudioSessionIdChanged);
       audioSessionIdState.runInBackground(
-          () ->
-              audioSessionIdState.setStateInBackground(
-                  Util.generateAudioSessionIdV21(applicationContext)));
+          () -> audioSessionIdState.setStateInBackground(
+                  new Pair( // MIREGO: use a distinct session for tunneling
+                    Util.generateAudioSessionIdV21(applicationContext),
+                    Util.generateAudioSessionIdV21(applicationContext))
+                  ));
       audioBecomingNoisyManager =
           new AudioBecomingNoisyManager(
               builder.context, playbackLooper, builder.looper, componentListener, clock);
@@ -1510,25 +1513,29 @@ import java.util.concurrent.CopyOnWriteArraySet;
     return audioAttributes;
   }
 
+  // MIREGO: use a distinct session for tunneling
   @Override
   public void setAudioSessionId(int audioSessionId) {
     verifyApplicationThread();
-    if (audioSessionIdState.get() == audioSessionId) {
+
+    Pair<Integer, Integer> currentSessions = audioSessionIdState.get();
+
+    if (currentSessions.first == audioSessionId && currentSessions.second == audioSessionId) {
       return;
     }
     audioSessionIdState.updateStateAsync(
         /* placeholderState= */ previousId ->
-            audioSessionId != AUDIO_SESSION_ID_UNSET ? audioSessionId : previousId,
+            audioSessionId != AUDIO_SESSION_ID_UNSET ? new Pair(audioSessionId, audioSessionId) : previousId,
         /* backgroundStateUpdate= */ previousId ->
             audioSessionId != AUDIO_SESSION_ID_UNSET
-                ? audioSessionId
-                : Util.generateAudioSessionIdV21(applicationContext));
+                ? new Pair(audioSessionId, audioSessionId)
+                : new Pair(Util.generateAudioSessionIdV21(applicationContext), Util.generateAudioSessionIdV21(applicationContext)));
   }
 
   @Override
   public int getAudioSessionId() {
     verifyApplicationThread();
-    return audioSessionIdState.get();
+    return audioSessionIdState.get().first; // MIREGO: use a distinct session for tunneling
   }
 
   @Override
@@ -3009,12 +3016,13 @@ import java.util.concurrent.CopyOnWriteArraySet;
     }
   }
 
-  private void onAudioSessionIdChanged(int oldAudioSessionId, int newAudioSessionId) {
+  // MIREGO: use a distinct session for tunneling
+  private void onAudioSessionIdChanged(Pair<Integer, Integer> oldAudioSessionId, Pair<Integer, Integer> newAudioSessionIds) {
     verifyApplicationThread();
-    sendRendererMessage(TRACK_TYPE_AUDIO, MSG_SET_AUDIO_SESSION_ID, newAudioSessionId);
-    sendRendererMessage(TRACK_TYPE_VIDEO, MSG_SET_AUDIO_SESSION_ID, newAudioSessionId);
+    sendRendererMessage(TRACK_TYPE_AUDIO, MSG_SET_AUDIO_SESSION_ID, newAudioSessionIds);
+    sendRendererMessage(TRACK_TYPE_VIDEO, MSG_SET_AUDIO_SESSION_ID, newAudioSessionIds);
     listeners.sendEvent(
-        EVENT_AUDIO_SESSION_ID, listener -> listener.onAudioSessionIdChanged(newAudioSessionId));
+        EVENT_AUDIO_SESSION_ID, listener -> listener.onAudioSessionIdChanged(newAudioSessionIds.first));
   }
 
   private static DeviceInfo createDeviceInfo(@Nullable StreamVolumeManager streamVolumeManager) {
@@ -3218,11 +3226,13 @@ import java.util.concurrent.CopyOnWriteArraySet;
       analyticsCollector.onAudioTrackReleased(audioTrackConfig);
     }
 
+
+    // MIREGO: use a distinct session for tunneling
     @Override
-    public void onAudioSessionIdChanged(int audioSessionId) {
+    public void onAudioSessionIdChanged(int audioSessionId, int tunnelingAudioSessionId) {
       audioSessionIdState.updateStateAsync(
-          /* placeholderState= */ previousId -> audioSessionId,
-          /* backgroundStateUpdate= */ previousId -> audioSessionId);
+          /* placeholderState= */ previousId -> new Pair(audioSessionId, tunnelingAudioSessionId),
+          /* backgroundStateUpdate= */ previousId -> new Pair(audioSessionId, tunnelingAudioSessionId));
     }
 
     // TextOutput implementation

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioRendererEventListener.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioRendererEventListener.java
@@ -165,7 +165,8 @@ public interface AudioRendererEventListener {
    *
    * @param audioSessionId The new audio session ID.
    */
-  default void onAudioSessionIdChanged(int audioSessionId) {}
+  // MIREGO: use a distinct session for tunneling
+  default void onAudioSessionIdChanged(int audioSessionId, int tunnelingAudioSessionId) {}
 
   /** Dispatches events to an {@link AudioRendererEventListener}. */
   final class EventDispatcher {
@@ -288,9 +289,10 @@ public interface AudioRendererEventListener {
     }
 
     /** Invokes {@link AudioRendererEventListener#onAudioSessionIdChanged}. */
-    public void audioSessionIdChanged(int audioSessionId) {
+    // MIREGO: use a distinct session for tunneling
+    public void audioSessionIdChanged(int audioSessionId, int tunnelingAudioSessionId) {
       if (handler != null) {
-        handler.post(() -> castNonNull(listener).onAudioSessionIdChanged(audioSessionId));
+        handler.post(() -> castNonNull(listener).onAudioSessionIdChanged(audioSessionId, tunnelingAudioSessionId));
       }
     }
   }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioSink.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioSink.java
@@ -160,11 +160,12 @@ public interface AudioSink {
      * Called when the audio session ID changed internally.
      *
      * <p>The audio sink will ignore new externally set audio session IDs until this ID has been
-     * acknowledged with {@link #setAudioSessionId(int)}.
+     * acknowledged with {@link #setAudioSessionId(int, int)}.
      *
      * @param audioSessionId The new audio session ID.
      */
-    default void onAudioSessionIdChanged(int audioSessionId) {}
+    // MIREGO: use a distinct session for tunneling
+    default void onAudioSessionIdChanged(int audioSessionId, int tunnelingAudioSessionId) {}
   }
 
   /** Configuration parameters used for an {@link AudioTrack}. */
@@ -588,8 +589,8 @@ public interface AudioSink {
   @Nullable
   AudioAttributes getAudioAttributes();
 
-  /** Sets the audio session id. */
-  void setAudioSessionId(int audioSessionId);
+  /** Sets the audio session id. */ // MIREGO: use a distinct session for tunneling
+  void setAudioSessionId(int audioSessionId, int tunnelingAudioSessionId);
 
   /** Sets the auxiliary effect. */
   void setAuxEffectInfo(AuxEffectInfo auxEffectInfo);

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DecoderAudioRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DecoderAudioRenderer.java
@@ -29,6 +29,7 @@ import static java.lang.annotation.ElementType.TYPE_USE;
 import android.media.AudioDeviceInfo;
 import android.os.Handler;
 import android.os.SystemClock;
+import android.util.Pair;
 import androidx.annotation.CallSuper;
 import androidx.annotation.IntDef;
 import androidx.annotation.Nullable;
@@ -794,7 +795,9 @@ public abstract class DecoderAudioRenderer<
         audioSink.setSkipSilenceEnabled((Boolean) message);
         break;
       case MSG_SET_AUDIO_SESSION_ID:
-        audioSink.setAudioSessionId((Integer) message);
+        // MIREGO: use a distinct session for tunneling
+        Pair<Integer, Integer> sessionIds = (Pair<Integer, Integer>) message;
+        audioSink.setAudioSessionId(sessionIds.first, sessionIds.second);
         break;
       case MSG_SET_PREFERRED_AUDIO_DEVICE:
         if (SDK_INT >= 23) {
@@ -979,9 +982,10 @@ public abstract class DecoderAudioRenderer<
       eventDispatcher.audioTrackReleased(audioTrackConfig);
     }
 
+    // MIREGO: use a distinct session for tunneling
     @Override
-    public void onAudioSessionIdChanged(int audioSessionId) {
-      eventDispatcher.audioSessionIdChanged(audioSessionId);
+    public void onAudioSessionIdChanged(int audioSessionId, int tunnelingAudioSessionId) {
+      eventDispatcher.audioSessionIdChanged(audioSessionId, tunnelingAudioSessionId);
     }
 
     @Override

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
@@ -610,6 +610,7 @@ public final class DefaultAudioSink implements AudioSink {
   private boolean playing;
   private boolean externalAudioSessionIdProvided;
   private int audioSessionId;
+  private int tunnelingAudioSessionId; // MIREGO: use a distinct session for tunneling
   private boolean pendingAudioSessionIdChangeConfirmation;
   private AuxEffectInfo auxEffectInfo;
   @Nullable private AudioDeviceInfoApi23 preferredDevice;
@@ -645,6 +646,7 @@ public final class DefaultAudioSink implements AudioSink {
         ImmutableList.of(trimmingAudioProcessor, channelMappingAudioProcessor);
     volume = 1f;
     audioSessionId = C.AUDIO_SESSION_ID_UNSET;
+    tunnelingAudioSessionId = C.AUDIO_SESSION_ID_UNSET; // MIREGO: use a distinct session for tunneling
     auxEffectInfo = new AuxEffectInfo(AuxEffectInfo.NO_AUX_EFFECT_ID, 0f);
     mediaPositionParameters =
         new MediaPositionParameters(
@@ -942,14 +944,23 @@ public final class DefaultAudioSink implements AudioSink {
     startMediaTimeUsNeedsInit = true;
 
     int newAudioSessionId = audioTrack.getAudioSessionId();
-    boolean audioSessionIdChanged = newAudioSessionId != audioSessionId;
-    audioSessionId = newAudioSessionId;
+
+    // MIREGO: use a distinct session for tunneling
+    boolean audioSessionIdChanged;
+    if (tunneling) {
+      audioSessionIdChanged = newAudioSessionId != tunnelingAudioSessionId;
+      tunnelingAudioSessionId = newAudioSessionId;
+    } else {
+      audioSessionIdChanged = newAudioSessionId != audioSessionId;
+      audioSessionId = newAudioSessionId;
+    }
 
     if (listener != null) {
       listener.onAudioTrackInitialized(configuration.buildAudioTrackConfig());
       if (audioSessionIdChanged) {
         pendingAudioSessionIdChangeConfirmation = true;
-        listener.onAudioSessionIdChanged(audioSessionId);
+        // MIREGO: use a distinct session for tunneling
+        listener.onAudioSessionIdChanged(audioSessionId, tunnelingAudioSessionId);
       }
     }
 
@@ -1216,7 +1227,9 @@ public final class DefaultAudioSink implements AudioSink {
   private AudioTrack buildAudioTrack(Configuration configuration) throws InitializationException {
     try {
       @Nullable Context contextForAudioTrack = null;
-      int audioSessionId = this.audioSessionId;
+      // MIREGO: use a distinct session for tunneling
+      int audioSessionId = tunneling ? tunnelingAudioSessionId : this.audioSessionId;
+
       if (contextDeviceId != C.INDEX_UNSET && context != null && SDK_INT >= 34) {
         if (contextWithDeviceId == null) {
           contextWithDeviceId = context.createDeviceContext(contextDeviceId);
@@ -1594,17 +1607,19 @@ public final class DefaultAudioSink implements AudioSink {
     return audioAttributes;
   }
 
+  // MIREGO: use a distinct session for tunneling
   @Override
-  public void setAudioSessionId(int audioSessionId) {
+  public void setAudioSessionId(int audioSessionId, int tunnelingAudioSessionId) {
     if (pendingAudioSessionIdChangeConfirmation) {
-      if (this.audioSessionId == audioSessionId) {
+      if ((this.audioSessionId == audioSessionId) && (this.tunnelingAudioSessionId == tunnelingAudioSessionId)) {
         pendingAudioSessionIdChangeConfirmation = false;
       } else {
         return;
       }
     }
-    if (this.audioSessionId != audioSessionId) {
+    if ((this.audioSessionId != audioSessionId) || (this.tunnelingAudioSessionId != tunnelingAudioSessionId)) {
       this.audioSessionId = audioSessionId;
+      this.tunnelingAudioSessionId = tunnelingAudioSessionId;
       externalAudioSessionIdProvided = audioSessionId != C.AUDIO_SESSION_ID_UNSET;
       flush();
     }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/ForwardingAudioSink.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/ForwardingAudioSink.java
@@ -141,9 +141,10 @@ public class ForwardingAudioSink implements AudioSink {
     return sink.getAudioAttributes();
   }
 
+  // MIREGO: use a distinct session for tunneling
   @Override
-  public void setAudioSessionId(int audioSessionId) {
-    sink.setAudioSessionId(audioSessionId);
+  public void setAudioSessionId(int audioSessionId, int tunnelingAudioSessionId) {
+    sink.setAudioSessionId(audioSessionId, tunnelingAudioSessionId);
   }
 
   @Override

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/MediaCodecAudioRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/MediaCodecAudioRenderer.java
@@ -16,6 +16,7 @@
 package androidx.media3.exoplayer.audio;
 
 import static android.os.Build.VERSION.SDK_INT;
+import static androidx.media3.common.C.AUDIO_SESSION_ID_UNSET;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.exoplayer.DecoderReuseEvaluation.DISCARD_REASON_MAX_INPUT_SIZE_EXCEEDED;
 import static androidx.media3.exoplayer.DecoderReuseEvaluation.REUSE_RESULT_NO;
@@ -59,6 +60,7 @@ import androidx.media3.exoplayer.FormatHolder;
 import androidx.media3.exoplayer.MediaClock;
 import androidx.media3.exoplayer.PlayerMessage.Target;
 import androidx.media3.exoplayer.RendererCapabilities;
+import androidx.media3.exoplayer.RendererConfiguration;
 import androidx.media3.exoplayer.audio.AudioRendererEventListener.EventDispatcher;
 import androidx.media3.exoplayer.audio.AudioSink.InitializationException;
 import androidx.media3.exoplayer.audio.AudioSink.WriteException;
@@ -113,6 +115,9 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
   private final EventDispatcher eventDispatcher;
   private final AudioSink audioSink;
   @Nullable private final LoudnessCodecController loudnessCodecController;
+
+  // MIREGO: use a distinct session for tunneling
+  private Pair<Integer, Integer> audioSessionIds = new Pair(AUDIO_SESSION_ID_UNSET, AUDIO_SESSION_ID_UNSET);
 
   private int codecMaxInputSize;
   private boolean codecNeedsDiscardChannelsWorkaround;
@@ -701,6 +706,7 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
     } else {
       audioSink.disableTunneling();
     }
+    updateLoudnessCodecControllerAudioSessionId(); // MIREGO: use a distinct session for tunneling
     audioSink.setPlayerId(getPlayerId());
     audioSink.setClock(getClock());
   }
@@ -1072,10 +1078,18 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
   }
 
   // MIREGO: use a distinct session for tunneling
-  private void setAudioSessionId(Pair<Integer, Integer> audioSessionId) {
-    audioSink.setAudioSessionId(audioSessionId.first, audioSessionId.second);
+  private void setAudioSessionId(Pair<Integer, Integer> audioSessionIds) {
+    this.audioSessionIds = audioSessionIds;
+    audioSink.setAudioSessionId(audioSessionIds.first, audioSessionIds.second);
+    updateLoudnessCodecControllerAudioSessionId();
+  }
+
+  // MIREGO: use a distinct session for tunneling
+  private void updateLoudnessCodecControllerAudioSessionId() {
     if (SDK_INT >= 35 && loudnessCodecController != null) {
-      loudnessCodecController.setAudioSessionId(audioSessionId.first);  //smo todo
+      if (getState() == STATE_ENABLED) {
+        loudnessCodecController.setAudioSessionId(getConfiguration().tunneling ? audioSessionIds.second : audioSessionIds.first);
+      }
     }
   }
 
@@ -1209,9 +1223,8 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
     // MIREGO: use a distinct session for tunneling
     @Override
     public void onAudioSessionIdChanged(int audioSessionId, int tunnelingAudioSessionId) {
-      if (SDK_INT >= 35 && loudnessCodecController != null) {
-        loudnessCodecController.setAudioSessionId(audioSessionId);  // smo here
-      }
+      audioSessionIds = new Pair<>(audioSessionId, tunnelingAudioSessionId);
+      updateLoudnessCodecControllerAudioSessionId();
       eventDispatcher.audioSessionIdChanged(audioSessionId, tunnelingAudioSessionId);
     }
   }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/MediaCodecAudioRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/MediaCodecAudioRenderer.java
@@ -940,7 +940,8 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
         audioSink.setSkipSilenceEnabled((Boolean) checkNotNull(message));
         break;
       case MSG_SET_AUDIO_SESSION_ID:
-        setAudioSessionId((int) checkNotNull(message));
+        // MIREGO: use a distinct session for tunneling
+        setAudioSessionId((Pair<Integer, Integer>) checkNotNull(message));
         break;
       case MSG_SET_PRIORITY:
         rendererPriority = (int) checkNotNull(message);
@@ -1070,10 +1071,11 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
     return mediaFormat;
   }
 
-  private void setAudioSessionId(int audioSessionId) {
-    audioSink.setAudioSessionId(audioSessionId);
+  // MIREGO: use a distinct session for tunneling
+  private void setAudioSessionId(Pair<Integer, Integer> audioSessionId) {
+    audioSink.setAudioSessionId(audioSessionId.first, audioSessionId.second);
     if (SDK_INT >= 35 && loudnessCodecController != null) {
-      loudnessCodecController.setAudioSessionId(audioSessionId);
+      loudnessCodecController.setAudioSessionId(audioSessionId.first);  //smo todo
     }
   }
 
@@ -1204,12 +1206,13 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
       eventDispatcher.audioTrackReleased(audioTrackConfig);
     }
 
+    // MIREGO: use a distinct session for tunneling
     @Override
-    public void onAudioSessionIdChanged(int audioSessionId) {
+    public void onAudioSessionIdChanged(int audioSessionId, int tunnelingAudioSessionId) {
       if (SDK_INT >= 35 && loudnessCodecController != null) {
-        loudnessCodecController.setAudioSessionId(audioSessionId);
+        loudnessCodecController.setAudioSessionId(audioSessionId);  // smo here
       }
-      eventDispatcher.audioSessionIdChanged(audioSessionId);
+      eventDispatcher.audioSessionIdChanged(audioSessionId, tunnelingAudioSessionId);
     }
   }
 

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -1191,7 +1191,9 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
         }
         break;
       case MSG_SET_AUDIO_SESSION_ID:
-        int tunnelingAudioSessionId = (int) checkNotNull(message);
+        // MIREGO: use a distinct session for tunneling
+        Pair<Integer, Integer> sessionIds = (Pair<Integer, Integer>) checkNotNull(message);
+        int tunnelingAudioSessionId = sessionIds.second;
         if (this.tunnelingAudioSessionId != tunnelingAudioSessionId) {
           this.tunnelingAudioSessionId = tunnelingAudioSessionId;
           if (tunneling) {

--- a/libraries/transformer/src/main/java/androidx/media3/transformer/AudioGraphInputAudioSink.java
+++ b/libraries/transformer/src/main/java/androidx/media3/transformer/AudioGraphInputAudioSink.java
@@ -286,8 +286,9 @@ import java.util.Objects;
     return false;
   }
 
+  // MIREGO: use a distinct session for tunneling
   @Override
-  public void setAudioSessionId(int audioSessionId) {}
+  public void setAudioSessionId(int audioSessionId, int tunnelingAudioSessionId) {}
 
   @Override
   public void setAuxEffectInfo(AuxEffectInfo auxEffectInfo) {}


### PR DESCRIPTION
We have an issue on at least one device, where when playing back with tunneling on, and then with tunneled off, audio tracks leak internally, until they can't be created anymore, and all further playbacks fail.
- Restarting the app resets the memory pool, but not the internal leaking. Which means after a restart of the app, playback will start to fail after a certain number of playbacks, regardless if tunneling is used in that execution. The device must be rebooted to fix the underlying faulty state.
- Not using a single ExoPlayer instance makes no difference.
- There's been a significant increase of that error on multiple platforms since UHD has been enabled on more devices. Not clear if this fix will have an impact on multiple of them, or just on the one we were able to reproduce the issue on.

Tried a bunch of things to understand what I could, considering the issue is in the os code, not in the app / ExoPlayer.

The workaround is to bring back an old workaround that had been lost a while ago when updating the ExoPlayer version. We use a distinct audio session id for tunneling, instead of sharing it with HD playback. My understanding of the issue is that a state that should be enabled only in tunneling stays on when tunneling is turned off. And that messes up with non-tunneled playback. Using different audio session id seems to avoid the issue. 

The original PR was in the ExoPlayer repository, before switching to androidX, and has been archived. Here's the commit to the initial import of the change to the new repository:
https://github.com/mirego/androidx-media/pull/1/commits/257f2b6f3ca8a8c31861f3bf514e3b6901a2054d

Copy of the PR comment:

> We encountered an issue where a non-tunneled playback would freeze if we played tunneled playback before with specific codecs.
> 
> From the ExoPlayer level, the issue was caused by the audioTrack timestamps stalling early in the playback. I was able to workaround by not reusing the audio session id for all the playbacks. Sounds simple, but that required quite a few tests...
> 
> My best guess is that the tunneled playback stalls the audio session id. The issue seems to be at the platform or codec level. Maybe the specific codec doesn't flush appropriately and stalls the audio session id. Or the audio session keeps a state form the tunneled playback that it shouldn't.
> 
> This PR works around the issue by creating 2 audio session ids instead of a single persisting one. We then use one for the non-tunneled playback, and the other one for the tunneled playback.
> 
> Also kept some logs I had added during the investigation.

It's been removed in a later upgrade, because the related code had changed. In hindsight, we should have ported the fix to the new code.