### PR TITLE
Fix playback time out when pendingAudioTrackReleaseShouldBlockNewTrackCreation and not using the single instance player (2)

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/PlaybackLooperProvider.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/PlaybackLooperProvider.java
@@ -102,7 +102,7 @@ public final class PlaybackLooperProvider {
       checkState(referenceCount > 0);
       referenceCount--;
       if (referenceCount == 0 && internalPlaybackThread != null) {
-        internalPlaybackThread.quit();
+        internalPlaybackThread.quitSafely(); // MIREGO: make sure the audioTrackThreadHandler messages are handled
         internalPlaybackThread = null;
         playbackLooper = null;
       }


### PR DESCRIPTION
In #40 we fixed an issue causing the audio tracks count to not get decreased when releasing the last audio track and the player.
It could still happen if the playback thread gets killed while the audio track "onReleased" message is still in the queue.
This PR fixes that other hole, by making sure the thread will properly flush its messages queue before terminating.
Making the world a better place one step at a time.