### PR TITLE
Support DRM restriction on video formats

### DIFF
--- a/libraries/common/src/main/java/androidx/media3/common/util/Util.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/Util.java
@@ -200,6 +200,8 @@ public final class Util {
 
   public static boolean workaroundAudioVolumePlatformGlitch = false;
 
+  public static boolean switchTrackOnDrmErrors = false; // MIREGO: fallback to different tracks when DRM fails
+
   // TEMP DEBUG STUFF (to investigate an infinite buffering issue caused by what seems to be a video codec stall)
   public static int videoLastFeedInputBufferStep = 0;
   public static int audioLastFeedInputBufferStep = 0;

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
@@ -88,8 +88,10 @@ import java.lang.annotation.Target;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayDeque;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.RequiresNonNull;
 
@@ -415,6 +417,9 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
   // MIREGO: added the following field and 2 functions to log and debug a specific issue (rendering pipleine stall)
   // MIREGO: once the issue is solved, we should get rid of that code
   protected boolean hasReportedRenderingStall = false;
+
+  // MIREGO: fallback to different tracks when DRM fails
+  protected Set<String> drmUnsupportedFormatSet = new HashSet<>();
 
   void saveFeedInputBufferStep(int stepIndex) {
     if (getTrackType() == TRACK_TYPE_AUDIO) {
@@ -846,6 +851,8 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
   protected void onReset() {
     hasReportedRenderingStall = false;
 
+    // MIREGO: fallback to different tracks when DRM fails, reset the set on new playback
+    drmUnsupportedFormatSet.clear();
     try {
       disableBypass();
       releaseCodec();
@@ -972,8 +979,15 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
       }
       decoderCounters.ensureUpdated();
     } catch (MediaCodec.CryptoException e) {
-      throw createRendererException(
-          e, inputFormat, Util.getErrorCodeForMediaDrmErrorCode(e.getErrorCode()));
+      if (Util.switchTrackOnDrmErrors) {
+        // MIREGO: fallback to other tracks on DRM errors
+        drmUnsupportedFormatSet.add(inputFormat.id);
+        inputFormat = null;
+        onRendererCapabilitiesChanged();
+      } else {
+        throw createRendererException(
+            e, inputFormat, Util.getErrorCodeForMediaDrmErrorCode(e.getErrorCode()));
+      }
     } catch (IllegalStateException e) {
       if (isMediaCodecException(e)) {
         onCodecError(e);

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
@@ -418,8 +418,7 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
   // MIREGO: once the issue is solved, we should get rid of that code
   protected boolean hasReportedRenderingStall = false;
 
-  // MIREGO: fallback to different tracks when DRM fails
-  protected Set<String> drmUnsupportedFormatSet = new HashSet<>();
+  private boolean drmFailedOnFormat = false; // MIREGO: fallback to different tracks when DRM fails
 
   void saveFeedInputBufferStep(int stepIndex) {
     if (getTrackType() == TRACK_TYPE_AUDIO) {
@@ -779,6 +778,10 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
       long offsetUs,
       MediaSource.MediaPeriodId mediaPeriodId)
       throws ExoPlaybackException {
+
+    // MIREGO: fallback on DRM fail. A new track has been selected, we can try playback with the new format
+    drmFailedOnFormat = false;
+
     if (outputStreamInfo.streamOffsetUs == C.TIME_UNSET) {
       // This is the first stream.
       setOutputStreamInfo(
@@ -850,9 +853,6 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
   @Override
   protected void onReset() {
     hasReportedRenderingStall = false;
-
-    // MIREGO: fallback to different tracks when DRM fails, reset the set on new playback
-    drmUnsupportedFormatSet.clear();
     try {
       disableBypass();
       releaseCodec();
@@ -939,6 +939,12 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
         renderToEndOfStream();
         return;
       }
+
+      // MIREGO: fallback on DRM fail. We want to wait until a new track has been selected, otherwise we'll just get the same error on the same format
+      if (inputFormat == null && drmFailedOnFormat) {
+        return;
+      }
+
       if (inputFormat == null && !readSourceOmittingSampleData(FLAG_REQUIRE_FORMAT)) {
         // We still don't have a format and can't make progress without one.
         return;
@@ -979,10 +985,10 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
       }
       decoderCounters.ensureUpdated();
     } catch (MediaCodec.CryptoException e) {
-      if (Util.switchTrackOnDrmErrors) {
-        // MIREGO: fallback to other tracks on DRM errors
-        drmUnsupportedFormatSet.add(inputFormat.id);
+      // MIREGO: modified catch block to fallback to other tracks on DRM errors
+      if (maybeHandleCryptoError(inputFormat)) {
         inputFormat = null;
+        drmFailedOnFormat = true;
         onRendererCapabilitiesChanged();
       } else {
         throw createRendererException(
@@ -1006,6 +1012,11 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
       }
       throw e;
     }
+  }
+
+  // MIREGO: fallback to other tracks on DRM errors
+  protected boolean maybeHandleCryptoError(Format format) {
+    return false;
   }
 
   /**

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
@@ -987,6 +987,7 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
     } catch (MediaCodec.CryptoException e) {
       // MIREGO: modified catch block to fallback to other tracks on DRM errors
       if (maybeHandleCryptoError(inputFormat)) {
+        Log.d(TAG, "handle crypto exception for format %s", inputFormat);
         inputFormat = null;
         drmFailedOnFormat = true;
         onRendererCapabilitiesChanged();

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -93,7 +93,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.PriorityQueue;
 import java.util.Set;
-import javax.annotation.Nonnull;
 import org.checkerframework.checker.initialization.qual.Initialized;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.RequiresNonNull;
@@ -438,7 +437,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
   private static final long NOTIFY_QUEUED_FRAMES_THRESHOLD = 100;
 
   // MIREGO: fallback to different tracks when DRM fails
-  protected Set<String> drmUnsupportedFormatSet = new HashSet<>();
+  private final Set<String> drmUnsupportedFormatSet = new HashSet<>();
 
   /**
    * @param context A context.

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -17,7 +17,6 @@ package androidx.media3.exoplayer.video;
 
 import static android.os.Build.VERSION.SDK_INT;
 import static android.view.Display.DEFAULT_DISPLAY;
-import static androidx.media3.common.C.TRACK_TYPE_VIDEO;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.common.util.Assertions.checkState;
 import static androidx.media3.common.util.Assertions.checkStateNotNull;
@@ -676,6 +675,11 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
   @Override
   protected @Capabilities int supportsFormat(MediaCodecSelector mediaCodecSelector, Format format)
       throws DecoderQueryException {
+
+    // MIREGO: fallback to other tracks when drm has failed on a format
+    if (drmUnsupportedFormatSet.contains(format.id)) {
+      return RendererCapabilities.create(C.FORMAT_UNSUPPORTED_DRM);
+    }
     return supportsFormatInternal(context, mediaCodecSelector, format);
   }
 

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -89,8 +89,11 @@ import androidx.media3.exoplayer.video.VideoRendererEventListener.EventDispatche
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.nio.ByteBuffer;
+import java.util.HashSet;
 import java.util.List;
 import java.util.PriorityQueue;
+import java.util.Set;
+import javax.annotation.Nonnull;
 import org.checkerframework.checker.initialization.qual.Initialized;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.RequiresNonNull;
@@ -433,6 +436,9 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
   private long queuedFrameAccumulationStartTimeMs;
   private static final long IGNORE_PRIMING_DROPPED_FRAMES_MS = 400; // when the tunneling is priming, it's expected that we'll get dropped frames. Ignore them.
   private static final long NOTIFY_QUEUED_FRAMES_THRESHOLD = 100;
+
+  // MIREGO: fallback to different tracks when DRM fails
+  protected Set<String> drmUnsupportedFormatSet = new HashSet<>();
 
   /**
    * @param context A context.
@@ -1146,6 +1152,9 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
 
   @Override
   protected void onReset() {
+    // MIREGO: fallback to different tracks when DRM fails, reset the formats set on new playback
+    drmUnsupportedFormatSet.clear();
+
     try {
       super.onReset();
     } finally {
@@ -2689,6 +2698,19 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
   protected MediaCodecDecoderException createDecoderException(
       Throwable cause, @Nullable MediaCodecInfo codecInfo) {
     return new MediaCodecVideoDecoderException(cause, codecInfo, displaySurface);
+  }
+
+  // MIREGO: fallback to other tracks on DRM errors
+  @Override
+  protected boolean maybeHandleCryptoError(Format format) {
+    // if the format is HD, it's most likely a DRM restriction, we can try to fallback to other formats
+    // if the format is SD, we assume this is an unexpected error and do not try to fall back
+    if (Util.switchTrackOnDrmErrors &&
+        ((format.width >= 1280) || (format.height >= 720))) {
+      drmUnsupportedFormatSet.add(format.id);
+      return true;
+    }
+    return false;
   }
 
   /**


### PR DESCRIPTION
We have to implement DRM restrictions on video playback. Specifically, L3 decryption will not be supported for HD and above.
Unfortunately, when BE implements that server side, the client playback fails on the HD track, and does not fall back to other tracks.
So this PR could also have been titled: Fallback to other tracks when getting a crypto exception on video playback.

It would have been nice to be able to implement that without having to stream some data and get the exception. Unfortunately, that would have required more extensive changes. There's been a ticket requesting a feature like that in ExoPlayer for a while: https://github.com/androidx/media/issues/1776

So in short, what we do:
- When we get a crypto exception, conditionally to a setting:
- we add the format id to a set of formats to disable for that playback
- we notify the track selector that our caps have changed (so that it can select a new track)
- we disable rendering until we got a new track

The app then needs to enable the switch, and also use setAllowInvalidateSelectionsOnRendererCapabilitiesChange(true) on the track selector. The name is self-explanatory.
