### PR TITLE
Give access to android MediaDrm

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/ExoMediaDrm.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/ExoMediaDrm.java
@@ -441,6 +441,11 @@ public interface ExoMediaDrm {
    * @return The generated key request.
    * @see MediaDrm#getKeyRequest(byte[], byte[], String, int, HashMap)
    */
+
+  // MIREGO added access to android MediaDrm
+  @Nullable
+  default MediaDrm getMediaDrm() {return null;}
+
   KeyRequest getKeyRequest(
       byte[] scope,
       @Nullable List<SchemeData> schemeDatas,

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/FrameworkMediaDrm.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/FrameworkMediaDrm.java
@@ -123,6 +123,12 @@ public final class FrameworkMediaDrm implements ExoMediaDrm {
     }
   }
 
+  // MIREGO added access to android MediaDrm
+  @Override
+  public MediaDrm getMediaDrm() {
+    return mediaDrm;
+  }
+
   @UnstableApi
   @Override
   public void setOnEventListener(@Nullable ExoMediaDrm.OnEventListener listener) {


### PR DESCRIPTION
We need to get the android MediaDrm that is owned by ExoMediaDrm, in order to read the connected hdcp level.