### PR TITLE
Send error when we reject all video tracks (restrictions)

### DIFF
--- a/libraries/common/src/main/java/androidx/media3/common/PlaybackException.java
+++ b/libraries/common/src/main/java/androidx/media3/common/PlaybackException.java
@@ -314,6 +314,9 @@ public class PlaybackException extends Exception {
   /** MIREGO: Caused by a Drm offline key hashcode not found in the hash codes array */
   public static final int ERROR_CODE_OFFLINE_DRM_HASH_CODE_NOT_FOUND = 5907;
 
+  /** MIREGO: Caused by tracks restriction preventing the selection of a video track */
+  public static final int ERROR_CODE_NO_VIDEO_TRACK_ELIGIBLE = 5908;
+  
   // DRM errors (6xxx).
 
   /** Caused by an unspecified error related to DRM protection. */
@@ -489,6 +492,8 @@ public class PlaybackException extends Exception {
         return "ERROR_CODE_VIDEO_CODEC_STALLED";
       case ERROR_CODE_OFFLINE_DRM_HASH_CODE_NOT_FOUND:
         return "ERROR_CODE_OFFLINE_DRM_HASH_CODE_NOT_FOUND";
+      case ERROR_CODE_NO_VIDEO_TRACK_ELIGIBLE:
+        return "ERROR_CODE_NO_VIDEO_TRACK_ELIGIBLE";
 
       default:
         if (errorCode >= CUSTOM_ERROR_CODE_BASE) {

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/trackselection/DefaultTrackSelector.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/trackselection/DefaultTrackSelector.java
@@ -51,6 +51,7 @@ import androidx.media3.common.C;
 import androidx.media3.common.C.RoleFlags;
 import androidx.media3.common.Format;
 import androidx.media3.common.MimeTypes;
+import androidx.media3.common.PlaybackException;
 import androidx.media3.common.Timeline;
 import androidx.media3.common.TrackGroup;
 import androidx.media3.common.TrackSelectionOverride;
@@ -3054,6 +3055,9 @@ public class DefaultTrackSelector extends MappingTrackSelector
       Comparator<List<T>> selectionComparator) {
     ArrayList<List<T>> possibleSelections = new ArrayList<>();
     int rendererCount = mappedTrackInfo.getRendererCount();
+
+    boolean hasNoEligibleTrack = false; // MIREGO added to notify error when all video tracks are restricted
+
     for (int rendererIndex = 0; rendererIndex < rendererCount; rendererIndex++) {
       if (trackType == mappedTrackInfo.getRendererType(rendererIndex)) {
         TrackGroupArray groups = mappedTrackInfo.getTrackGroups(rendererIndex);
@@ -3065,6 +3069,11 @@ public class DefaultTrackSelector extends MappingTrackSelector
           for (int trackIndex = 0; trackIndex < trackGroup.length; trackIndex++) {
             T trackInfo = trackInfos.get(trackIndex);
             @SelectionEligibility int eligibility = trackInfo.getSelectionEligibility();
+
+            // MIREGO added to notify error when all video tracks are restricted
+            if (trackInfo.getSelectionEligibility() == SELECTION_ELIGIBILITY_NO) {
+              hasNoEligibleTrack = true;
+            }
             if (usedTrackInSelection[trackIndex] || eligibility == SELECTION_ELIGIBILITY_NO) {
               continue;
             }
@@ -3094,6 +3103,12 @@ public class DefaultTrackSelector extends MappingTrackSelector
       }
     }
     if (possibleSelections.isEmpty()) {
+      // MIREGO added to notify error when all video tracks are restricted
+      if (trackType == C.TRACK_TYPE_VIDEO && hasNoEligibleTrack) {
+        Log.e(TAG,
+            new PlaybackException("No video track selected (none eligible)", new RuntimeException(),
+                PlaybackException.ERROR_CODE_NO_VIDEO_TRACK_ELIGIBLE));
+      }
       return null;
     }
     List<T> bestSelection = max(possibleSelections, selectionComparator);

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/trackselection/DefaultTrackSelector.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/trackselection/DefaultTrackSelector.java
@@ -3070,11 +3070,11 @@ public class DefaultTrackSelector extends MappingTrackSelector
             T trackInfo = trackInfos.get(trackIndex);
             @SelectionEligibility int eligibility = trackInfo.getSelectionEligibility();
 
-            // MIREGO added to notify error when all video tracks are restricted
-            if (trackInfo.getSelectionEligibility() == SELECTION_ELIGIBILITY_NO) {
-              hasNoEligibleTrack = true;
-            }
             if (usedTrackInSelection[trackIndex] || eligibility == SELECTION_ELIGIBILITY_NO) {
+              // MIREGO added to notify error when all video tracks are restricted
+              if (eligibility == SELECTION_ELIGIBILITY_NO) {
+                hasNoEligibleTrack = true;
+              }
               continue;
             }
             List<T> selection;


### PR DESCRIPTION
In #44 we added a way to handle drm restrictions and fallback to other tracks when a track is restricted (because of insufficient drm security level or hdcp). We also added restrictions on the app side to use max video size to preemptively avoid selecting the unplayable tracks.

On some streams (4K), it could mean that no video tracks are available. It's not a great UX, since we still have the audio playing on a black screen.

This PR adds an error log when:
- there are video tracks
- none of them are eligible

The app can then use the error and opt to stop playback and display an error screen.
