### PR TITLE
Facilitate usage of custom MediaCodecVideoRenderers

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/DefaultRenderersFactory.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/DefaultRenderersFactory.java
@@ -432,6 +432,7 @@ public class DefaultRenderersFactory implements RenderersFactory {
       VideoRendererEventListener eventListener,
       long allowedVideoJoiningTimeMs,
       ArrayList<Renderer> out) {
+    // MIREGO: Adds ability to use a custom MediaCodecVideoRenderer by providing a  custom builder for it.
     videoRendererBuilder
         .setCodecAdapterFactory(getCodecAdapterFactory())
         .setMediaCodecSelector(mediaCodecSelector)

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/DefaultRenderersFactory.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/DefaultRenderersFactory.java
@@ -423,7 +423,8 @@ public class DefaultRenderersFactory implements RenderersFactory {
    * @param out An array to which the built renderers should be appended.
    */
   protected void buildVideoRenderers(
-      Context context,
+      // MIREGO: Adds ability to use a custom MediaCodecVideoRenderer by providing a  custom builder for it.
+      MediaCodecVideoRenderer.Builder videoRendererBuilder,
       @ExtensionRendererMode int extensionRendererMode,
       MediaCodecSelector mediaCodecSelector,
       boolean enableDecoderFallback,
@@ -431,17 +432,16 @@ public class DefaultRenderersFactory implements RenderersFactory {
       VideoRendererEventListener eventListener,
       long allowedVideoJoiningTimeMs,
       ArrayList<Renderer> out) {
-    MediaCodecVideoRenderer.Builder videoRendererBuilder =
-        new MediaCodecVideoRenderer.Builder(context)
-            .setCodecAdapterFactory(getCodecAdapterFactory())
-            .setMediaCodecSelector(mediaCodecSelector)
-            .setAllowedJoiningTimeMs(allowedVideoJoiningTimeMs)
-            .setEnableDecoderFallback(enableDecoderFallback)
-            .setEventHandler(eventHandler)
-            .setEventListener(eventListener)
-            .setMaxDroppedFramesToNotify(MAX_DROPPED_VIDEO_FRAME_COUNT_TO_NOTIFY)
-            .experimentalSetParseAv1SampleDependencies(parseAv1SampleDependencies)
-            .experimentalSetLateThresholdToDropDecoderInputUs(lateThresholdToDropDecoderInputUs);
+    videoRendererBuilder
+        .setCodecAdapterFactory(getCodecAdapterFactory())
+        .setMediaCodecSelector(mediaCodecSelector)
+        .setAllowedJoiningTimeMs(allowedVideoJoiningTimeMs)
+        .setEnableDecoderFallback(enableDecoderFallback)
+        .setEventHandler(eventHandler)
+        .setEventListener(eventListener)
+        .setMaxDroppedFramesToNotify(MAX_DROPPED_VIDEO_FRAME_COUNT_TO_NOTIFY)
+        .experimentalSetParseAv1SampleDependencies(parseAv1SampleDependencies)
+        .experimentalSetLateThresholdToDropDecoderInputUs(lateThresholdToDropDecoderInputUs);
     if (SDK_INT >= 34) {
       videoRendererBuilder =
           videoRendererBuilder.experimentalSetEnableMediaCodecBufferDecodeOnlyFlag(
@@ -544,6 +544,30 @@ public class DefaultRenderersFactory implements RenderersFactory {
       // The extension is present, but instantiation failed.
       throw new IllegalStateException("Error instantiating FFmpeg extension", e);
     }
+  }
+
+  // MIREGO: Custom MediaCodecVideoRenderer builder
+  protected void buildVideoRenderers(
+      Context context,
+      @ExtensionRendererMode int extensionRendererMode,
+      MediaCodecSelector mediaCodecSelector,
+      boolean enableDecoderFallback,
+      Handler eventHandler,
+      VideoRendererEventListener eventListener,
+      long allowedVideoJoiningTimeMs,
+      ArrayList<Renderer> out) {
+    MediaCodecVideoRenderer.Builder builder = new MediaCodecVideoRenderer.Builder(context);
+
+    buildVideoRenderers(
+        builder,
+        extensionRendererMode,
+        mediaCodecSelector,
+        enableDecoderFallback,
+        eventHandler,
+        eventListener,
+        allowedVideoJoiningTimeMs,
+        out
+    );
   }
 
   /**

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/DefaultRenderersFactory.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/DefaultRenderersFactory.java
@@ -556,10 +556,8 @@ public class DefaultRenderersFactory implements RenderersFactory {
       VideoRendererEventListener eventListener,
       long allowedVideoJoiningTimeMs,
       ArrayList<Renderer> out) {
-    MediaCodecVideoRenderer.Builder builder = new MediaCodecVideoRenderer.Builder(context);
-
     buildVideoRenderers(
-        builder,
+        new MediaCodecVideoRenderer.Builder(context),
         extensionRendererMode,
         mediaCodecSelector,
         enableDecoderFallback,

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/DefaultRenderersFactory.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/DefaultRenderersFactory.java
@@ -423,7 +423,7 @@ public class DefaultRenderersFactory implements RenderersFactory {
    * @param out An array to which the built renderers should be appended.
    */
   protected void buildVideoRenderers(
-      // MIREGO: Adds ability to use a custom MediaCodecVideoRenderer by providing a  custom builder for it.
+      // MIREGO: Adds ability to use a custom MediaCodecVideoRenderer by providing a custom builder for it.
       MediaCodecVideoRenderer.Builder videoRendererBuilder,
       @ExtensionRendererMode int extensionRendererMode,
       MediaCodecSelector mediaCodecSelector,
@@ -432,7 +432,7 @@ public class DefaultRenderersFactory implements RenderersFactory {
       VideoRendererEventListener eventListener,
       long allowedVideoJoiningTimeMs,
       ArrayList<Renderer> out) {
-    // MIREGO: Adds ability to use a custom MediaCodecVideoRenderer by providing a  custom builder for it.
+    // MIREGO: Adds ability to use a custom MediaCodecVideoRenderer by providing a custom builder for it.
     videoRendererBuilder
         .setCodecAdapterFactory(getCodecAdapterFactory())
         .setMediaCodecSelector(mediaCodecSelector)

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -229,7 +229,8 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
   private int consecutiveDroppedInputBufferCount;
 
   /** A builder to create {@link MediaCodecVideoRenderer} instances. */
-  public static final class Builder {
+  // MIREGO: Make class non-final to allow custom Builder subclass to be provided to DefaultRenderersFactory.buildVideoRenderers.
+  public static class Builder {
     private final Context context;
     private boolean buildCalled;
     private MediaCodecSelector mediaCodecSelector;


### PR DESCRIPTION
This pull request introduces enhancements to the video renderer creation process in ExoPlayer, specifically to allow for more flexibility when using custom `MediaCodecVideoRenderer` implementations. The main change is to enable clients to provide their own builder for the video renderer, facilitating customization and extension without modifying core logic.

Renderer customization improvements:

* The `MediaCodecVideoRenderer.Builder` class is no longer `final`, making it possible to subclass and provide custom builder implementations.
* The `DefaultRenderersFactory.buildVideoRenderers` method is overloaded to accept a custom `MediaCodecVideoRenderer.Builder`, enabling the use of customized video renderers.
* A new overload of `buildVideoRenderers` is provided for backward compatibility, which creates a default builder and delegates to the new method.