### PR TITLE
Skip track selection for disabled track types

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/trackselection/DefaultTrackSelector.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/trackselection/DefaultTrackSelector.java
@@ -3056,12 +3056,12 @@ public class DefaultTrackSelector extends MappingTrackSelector
     ArrayList<List<T>> possibleSelections = new ArrayList<>();
     int rendererCount = mappedTrackInfo.getRendererCount();
 
-    boolean hasNoEligibleTrack = false; // MIREGO added to notify error when all video tracks are restricted
-
     // MIREGO: skip track selection if the type is disabled. We want to avoid the useless ERROR_CODE_NO_VIDEO_TRACK_ELIGIBLE error (and also the processing)
     if (parameters.disabledTrackTypes.contains(trackType)) {
       return null;
     }
+
+    boolean hasNoEligibleTrack = false; // MIREGO added to notify error when all video tracks are restricted
 
     for (int rendererIndex = 0; rendererIndex < rendererCount; rendererIndex++) {
       if (trackType == mappedTrackInfo.getRendererType(rendererIndex)) {

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/trackselection/DefaultTrackSelector.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/trackselection/DefaultTrackSelector.java
@@ -3058,6 +3058,11 @@ public class DefaultTrackSelector extends MappingTrackSelector
 
     boolean hasNoEligibleTrack = false; // MIREGO added to notify error when all video tracks are restricted
 
+    // MIREGO: skip track selection if the type is disabled. We want to avoid the useless ERROR_CODE_NO_VIDEO_TRACK_ELIGIBLE error (and also the processing)
+    if (parameters.disabledTrackTypes.contains(trackType)) {
+      return null;
+    }
+
     for (int rendererIndex = 0; rendererIndex < rendererCount; rendererIndex++) {
       if (trackType == mappedTrackInfo.getRendererType(rendererIndex)) {
         TrackGroupArray groups = mappedTrackInfo.getTrackGroups(rendererIndex);


### PR DESCRIPTION
In #48 we added an error when there are video tracks but none is eligible. We did that so we can output a relevant error message, should all video tracks be rejected because of DRM or HDCP restrictions.
That created an issue with downloads. The DownloadHelper also does a track selection, and all video tracks are rejected, since we do not have a valid DRM session at that moment. It's irrelevant to us, since we do the track selection manually later on, and completely ignore the track selection done by the helper.
Unfortunately, there is no simple way to disable that processing and the error to be sent. Even disabling track types had no effect, since the helper will still do all the work, and then discard the result if the track type is disabled.

This PR improves the download helper by skipping the selection of disabled track types. That should have been done that way, anyway. So by disabling them in the params for downloads, we'll be able to avoid that error, and all the useless processing.