### PR TITLE
FONM-21831 - Fix Closed Captions not displayed on Dolby Vision streams

### DIFF
--- a/libraries/container/src/main/java/androidx/media3/container/NalUnitUtil.java
+++ b/libraries/container/src/main/java/androidx/media3/container/NalUnitUtil.java
@@ -638,11 +638,10 @@ public final class NalUnitUtil {
    *     the {@code MimeType} is {@code null}.
    */
   public static boolean isNalUnitSei(Format format, byte nalUnitHeaderFirstByte) {
-    return ((Objects.equals(format.sampleMimeType, MimeTypes.VIDEO_H264)
-                || containsCodecsCorrespondingToMimeType(format.codecs, MimeTypes.VIDEO_H264))
+    String nalStructureMimeType = getNalStructureMimeType(format);
+    return (MimeTypes.VIDEO_H264.equals(nalStructureMimeType)
             && (nalUnitHeaderFirstByte & 0x1F) == H264_NAL_UNIT_TYPE_SEI)
-        || ((Objects.equals(format.sampleMimeType, MimeTypes.VIDEO_H265)
-                || containsCodecsCorrespondingToMimeType(format.codecs, MimeTypes.VIDEO_H265))
+        || (MimeTypes.VIDEO_H265.equals(nalStructureMimeType)
             && ((nalUnitHeaderFirstByte & 0x7E) >> 1) == H265_NAL_UNIT_TYPE_PREFIX_SEI);
   }
 
@@ -705,14 +704,43 @@ public final class NalUnitUtil {
    * @param format The sample {@link Format}.
    */
   public static int numberOfBytesInNalUnitHeader(Format format) {
-    if (Objects.equals(format.sampleMimeType, MimeTypes.VIDEO_H264)) {
+    String nalStructureMimeType = getNalStructureMimeType(format);
+    if (MimeTypes.VIDEO_H264.equals(nalStructureMimeType)) {
       return 1;
     }
-    if (Objects.equals(format.sampleMimeType, MimeTypes.VIDEO_H265)
-        || MimeTypes.containsCodecsCorrespondingToMimeType(format.codecs, MimeTypes.VIDEO_H265)) {
+    if (MimeTypes.VIDEO_H265.equals(nalStructureMimeType)) {
       return 2;
     }
     return 0;
+  }
+
+  /**
+   * Returns {@link Format#sampleMimeType}, or the MIME type of the structure of the underlying NAL
+   * units if different.
+   *
+   * <p>For example, Dolby Vision content (with MIME type {@link MimeTypes#VIDEO_DOLBY_VISION}) can
+   * be encoded with H.264 or H.265 NAL units.
+   *
+   * <p>Note: This only indicates the structure of the NAL units, it does not necessarily mean the
+   * content can be correctly decoded by a decoder of the returned MIME type (backwards
+   * compatibility). This can be queried with {@code
+   * androidx.media3.exoplayer.decoder.MediaCodecUtil#getAlternativeCodecMimeType(Format)} instead.
+   */
+  @Nullable
+  private static String getNalStructureMimeType(Format format) {
+    if (format.codecs != null) {
+      // Check each codec string for Dolby Vision prefixes that imply a specific NAL structure.
+      for (String codec : format.codecs.split(",")) {
+        codec = codec.trim();
+        if (codec.startsWith("dvh1") || codec.startsWith("dvhe")) {
+          return MimeTypes.VIDEO_H265;
+        }
+        if (codec.startsWith("dva1") || codec.startsWith("dvav")) {
+          return MimeTypes.VIDEO_H264;
+        }
+      }
+    }
+    return format.sampleMimeType;
   }
 
   /**


### PR DESCRIPTION
## Description

Closed captions were not displaying on HDR/Dolby Vision live streams despite being enabled by the user. In the given stream on klab1, CEA-608 data is present in the segments, but ExoPlayer fails to extract it.

This is a known bug in Exoplayer: [androidx/media#2775](https://github.com/androidx/media/issues/2775), fixed in commit [5e2e577](https://github.com/androidx/media/commit/5e2e577bc7db4b0f03541b6f6e9df18c2982fdc4). We cannot upgrade beyond version 1.8.0 at this time, so the upstream fix from commit `5e2e577` is applied directly to our fork.

## Tests
Playback tests on 7802:
- https://bell-nscreen-lab.g.i.kprod.f0ns3.ca/dashboard/runs/h8y07b57eikn8cq
- https://bell-nscreen-lab.g.i.kprod.f0ns3.ca/dashboard/runs/ie634xlrzyw7mcd/?test=ahxk4o4zpj6skqr&image=

## Result
Verified on the `TSN1H_SB` channel that closed captions are now correctly displayed on Dolby Vision streams.