### PR TITLE
Clear events between playbacks

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/analytics/DefaultAnalyticsCollector.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/analytics/DefaultAnalyticsCollector.java
@@ -568,6 +568,14 @@ public class DefaultAnalyticsCollector implements AnalyticsCollector {
         eventTime,
         AnalyticsListener.EVENT_PLAYBACK_STATE_CHANGED,
         listener -> listener.onPlaybackStateChanged(eventTime, playbackState));
+
+    // MIREGO added block to clear events between playbacks
+    if (playbackState == Player.STATE_IDLE) {
+      // Clear eventTimes to release references to Timeline/MediaItem objects from past playbacks.
+      // MSG_ITERATION_FINISHED is always sent to the front of the handler queue, so posting this
+      // to the back guarantees all pending onEvents deliveries complete before we clear.
+      checkNotNull(handler).post(eventTimes::clear);
+    }
   }
 
   @Override

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/analytics/DefaultAnalyticsCollector.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/analytics/DefaultAnalyticsCollector.java
@@ -130,6 +130,7 @@ public class DefaultAnalyticsCollector implements AnalyticsCollector {
     checkState(this.player == null || mediaPeriodQueueTracker.mediaPeriodQueue.isEmpty());
     this.player = checkNotNull(player);
     handler = clock.createHandler(looper, null);
+    resetBetweenPlaybacks();
     listeners =
         listeners.copy(
             looper,

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/analytics/DefaultAnalyticsCollector.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/analytics/DefaultAnalyticsCollector.java
@@ -73,9 +73,9 @@ import org.checkerframework.checker.nullness.qual.RequiresNonNull;
 public class DefaultAnalyticsCollector implements AnalyticsCollector {
 
   private final Clock clock;
-  private final Period period;
-  private final Window window;
-  private final MediaPeriodQueueTracker mediaPeriodQueueTracker;
+  private Period period; // MIREGO: removed final to reset when flushing
+  private Window window; // MIREGO: removed final to reset when flushing
+  private MediaPeriodQueueTracker mediaPeriodQueueTracker; // MIREGO: removed final to reset when flushing
   private final SparseArray<EventTime> eventTimes;
 
   private ListenerSet<AnalyticsListener> listeners;
@@ -571,10 +571,10 @@ public class DefaultAnalyticsCollector implements AnalyticsCollector {
 
     // MIREGO added block to clear events between playbacks
     if (playbackState == Player.STATE_IDLE) {
-      // Clear eventTimes to release references to Timeline/MediaItem objects from past playbacks.
+      // Reset data from previous playback to release references to Timeline/MediaItem objects from past playbacks.
       // MSG_ITERATION_FINISHED is always sent to the front of the handler queue, so posting this
       // to the back guarantees all pending onEvents deliveries complete before we clear.
-      checkNotNull(handler).post(eventTimes::clear);
+      checkNotNull(handler).post(this::resetBetweenPlaybacks);
     }
   }
 
@@ -921,6 +921,14 @@ public class DefaultAnalyticsCollector implements AnalyticsCollector {
       EventTime eventTime, int eventFlag, ListenerSet.Event<AnalyticsListener> eventInvocation) {
     eventTimes.put(eventFlag, eventTime);
     listeners.sendEvent(eventFlag, eventInvocation);
+  }
+
+  // MIREGO: clear eventTimes, to avoids retaining event times and stuff from previous playbacks
+  private void resetBetweenPlaybacks() {
+    eventTimes.clear();
+    period = new Period();
+    window = new Window();
+    mediaPeriodQueueTracker = new MediaPeriodQueueTracker(period);
   }
 
   /** Generates an {@link EventTime} for the currently playing item in the player. */


### PR DESCRIPTION
ExoPlayer has a pretty complex events notification system. It keeps the last event time of each type in a sparse array, to send them as a batch to listeners after a message queue iteration.
Those events times entries are never cleared, so they retain the last message sent of each type, until there's a new one. That's a bit problematic for events that are not frequent, because they can retain stuff from previous playbacks for a while.

This PR fixes it, by clearing that array between playbacks.

Special Thanks to Claudette, without you this would have taken me longer, and maybe my solution wouldn't have been as simple.