### PR TITLE
Log for a failing check

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/SampleQueue.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/SampleQueue.java
@@ -278,7 +278,12 @@ public class SampleQueue implements TrackOutput {
     if (length == 0) {
       return;
     }
-    checkArgument(timeUs > getLargestReadTimestampUs());
+    // MIREGO modified argument check code to log before failing the check
+    long  largestReadTimestampUs = getLargestReadTimestampUs();
+    if (timeUs <= largestReadTimestampUs) {
+      Log.d(TAG, "timeUs (%d) <= largestReadTimestampUs (%d) checkArgument will fail", timeUs, largestReadTimestampUs);
+    }
+    checkArgument(timeUs > largestReadTimestampUs);
     int retainCount = countUnreadSamplesBefore(timeUs);
     discardUpstreamSamples(absoluteFirstIndex + retainCount);
   }


### PR DESCRIPTION
This was meant to be included in a recent logs PR, but was forgotten.
Just a log before a failing check that happens sometimes in production.
Might help to find the root cause.