### PR TITLE
Work around pause issue on firestick 4k in tunneled playback

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
@@ -1534,7 +1534,7 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
 
   // MIREGO : Added to prevent an issue on some devices where the video would still render when paused in tunneled playback if we continue feeding the buffer.
   // It looks like it's rendering when it's full, so if we keep sending frames, we don't get to a point where the codec wouldn't return an available buffer until the playback is resumed.
-  // Instead, it renders a bunch of frames from to time, and it keeps getting more and more ahead of the audio feed. Overriden for the video renderer.
+  // Instead, it renders a bunch of frames from time to time, and it keeps getting more and more ahead of the audio feed. Overriden for the video renderer.
   protected boolean allowFeedInputBuffer() {
     return true;
   }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
@@ -1532,6 +1532,13 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
     codecDrmSession = session;
   }
 
+  // MIREGO : Added to prevent an issue on some devices where the video would still render when paused in tunneled playback if we continue feeding the buffer.
+  // It looks like it's rendering when it's full, so if we keep sending frames, we don't get to a point where the codec wouldn't return an available buffer until the playback is resumed.
+  // Instead, it renders a bunch of frames from to time, and it keeps getting more and more ahead of the audio feed. Overriden for the video renderer.
+  protected boolean allowFeedInputBuffer() {
+    return true;
+  }
+
   /**
    * @return Whether it may be possible to feed more input data.
    * @throws ExoPlaybackException If an error occurs feeding the input buffer.
@@ -1540,6 +1547,11 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
     // MIREGO
     Log.v(Log.LOG_LEVEL_VERBOSE3, TAG, "feedInputBuffer(type:%d) codecDrainState %d inputStreamEnded: %s",
         getTrackType(), codecDrainState, inputStreamEnded);
+
+    // MIREGO added to work around an issue in tunneled playback when paused on some devices
+    if (!allowFeedInputBuffer()) {
+      return false;
+    }
 
     if (codec == null || codecDrainState == DRAIN_STATE_WAIT_END_OF_STREAM || inputStreamEnded) {
       saveFeedInputBufferStep(1);

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -1120,7 +1120,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
 
   // MIREGO : Added to prevent an issue on some devices where the video would still render when paused in tunneled playback if we continue feeding the buffer.
   // It looks like it's rendering when it's full, so if we keep sending frames, we don't get to a point where the codec wouldn't return an available buffer until the playback is resumed.
-  // Instead, it renders a bunch of frames from to time, and it keeps getting more and more ahead of the audio feed.
+  // Instead, it renders a bunch of frames from time to time, and it keeps getting more and more ahead of the audio feed.
   // Blocking the feeding of the input buffer while we're paused in tunneling prevents that situation.
   protected boolean allowFeedInputBuffer() {
     return !isStopped || !tunneling;

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -1139,7 +1139,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
     if (videoFrameReleaseEarlyTimeForecaster != null) {
       videoFrameReleaseEarlyTimeForecaster.reset();
     }
-    isStopped = true; //MIREGO added
+    isStopped = true; // MIREGO added
     super.onStopped();
   }
 

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -228,6 +228,8 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
 
   private int consecutiveDroppedInputBufferCount;
 
+  private boolean isStopped = false; // MIREGO: added
+
   /** A builder to create {@link MediaCodecVideoRenderer} instances. */
   // MIREGO: Make class non-final to allow custom Builder subclass to be provided to DefaultRenderersFactory.buildVideoRenderers.
   public static class Builder {
@@ -1112,7 +1114,16 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
     hasNotifiedAvDesyncSkippedFramesError = false;
     queuedFrames = 0;
 
+    isStopped = false; // MIREGO: added
     videoFrameReleaseControl.onStarted();
+  }
+
+  // MIREGO : Added to prevent an issue on some devices where the video would still render when paused in tunneled playback if we continue feeding the buffer.
+  // It looks like it's rendering when it's full, so if we keep sending frames, we don't get to a point where the codec wouldn't return an available buffer until the playback is resumed.
+  // Instead, it renders a bunch of frames from to time, and it keeps getting more and more ahead of the audio feed.
+  // Blocking the feeding of the input buffer while we're paused in tunneling prevents that situation.
+  protected boolean allowFeedInputBuffer() {
+    return !isStopped || !tunneling;
   }
 
   @Override
@@ -1128,6 +1139,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
     if (videoFrameReleaseEarlyTimeForecaster != null) {
       videoFrameReleaseEarlyTimeForecaster.reset();
     }
+    isStopped = true; //MIREGO added
     super.onStopped();
   }
 


### PR DESCRIPTION
On firesticks 4k, there is an issue with pause during tunneled playback. The video feeds continue to play, by regular busts (every couple of seconds). It looks like the tunneled pipeline, when it has a lot of buffers ready to be processed, would release them, even though they shouldn't be, according to the presentation time.

Normally, the frames wouldn't get released, and eventually the renderer wouldn't be able to get an input buffer to write to. But that doesn't happen in this situation, so the video playback continue by bursts indefinitely. 

This PR works around the issue by stopping the input buffer feed when we're paused in tunneled playback.