### PR TITLE
Make `HttpMediaDrmCallback#getKeyRequestProperties` thread-safe

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/HttpMediaDrmCallback.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/HttpMediaDrmCallback.java
@@ -113,7 +113,7 @@ public final class HttpMediaDrmCallback implements MediaDrmCallback {
   }
 
   // MIREGO
-  public Map<String, String> getKeyRequestProperties() {
+  public Map<String, String> getKeyRequestPropertiesSnapshot() {
     synchronized (keyRequestProperties) {
       return ImmutableMap.copyOf(keyRequestProperties);
     }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/HttpMediaDrmCallback.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/HttpMediaDrmCallback.java
@@ -114,7 +114,9 @@ public final class HttpMediaDrmCallback implements MediaDrmCallback {
 
   // MIREGO
   public Map<String, String> getKeyRequestProperties() {
-    return keyRequestProperties;
+    synchronized (keyRequestProperties) {
+      return ImmutableMap.copyOf(keyRequestProperties);
+    }
   }
 
   @Override


### PR DESCRIPTION
## Context

`HttpMediaDrmCallback` is accessed concurrently: `setKeyRequestProperty` runs on one thread while `executeKeyRequest` reads the headers from ExoPlayer's DRM worker thread. The setter synchronizes on the `keyRequestProperties` map, but the `getKeyRequestProperties` getter returned the live reference without synchronization, forcing callers to lock externally to iterate it safely.

## Work done
- [x] Make `getKeyRequestProperties` return an `ImmutableMap` snapshot taken under the same lock that the as the other method that writes into`keyRequestProperties` making the function thread-safe.